### PR TITLE
Add ability to setup environment variables before calling Maven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to the "vscode-maven" extension will be documented in this f
 
 ## Unreleased
 
+### 0.7.0
+- Added support for setting JAVA_HOME and other environment variables through configuration settings.
+
 ## Released
 ### 0.6.0
 - Supported to auto-update maven project explorer tree view when pom.xml has been created/modified/removed.

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ This extension (Maven for Java) can reuse that setting if you desire:
     }
 ```
 
-With this support, you can specify JAVA_HOME in one place and you don't need to use the `maven.terminal.customEnv` setting unless
+With this support, you can specify JAVA_HOME in one place and you do not need to use the `maven.terminal.customEnv` setting unless
 you have other environment variables to set.
 
-If you have JAVA_HOME configured through the `maven.terminal.customEnv` setting, and also specify to reuse the Red Hat setting, then value from `maven.terminal.customEnv` will take precedent.
+If you have JAVA_HOME configured through the `maven.terminal.customEnv` setting, and also specify to reuse the Red Hat setting, then the value from `maven.terminal.customEnv` will take precedent.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This extension (Maven for Java) can reuse that setting if you desire:
 With this support, you can specify JAVA_HOME in one place and you do not need to use the `maven.terminal.customEnv` setting unless
 you have other environment variables to set.
 
-If you have JAVA_HOME configured through the `maven.terminal.customEnv` setting, and also specify to reuse the Red Hat setting, then the value from `maven.terminal.customEnv` will take precedent.
+If you have JAVA_HOME configured through the `maven.terminal.customEnv` setting, and also specify to reuse the Red Hat setting, then the value from `maven.terminal.customEnv` will take precedence.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,49 @@ Provide Maven executable filepath.
 
 VS Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](http://go.microsoft.com/fwlink/?LinkId=521839) to learn more. If you don’t wish to send usage data to Microsoft, you can set the `telemetry.enableTelemetry` setting to `false`. Learn more in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 
+## JAVA_HOME and Other Environment Variables
+
+This extension executes Maven by opening a terminal session and then calling Maven in that session.
+Maven requires the JAVA_HOME environment variable to be set. Maven will also look for other variables such as MAVEN_OPTS. If you prefer not to set those variables permanently you can configure them, or any other environment variable, in settings:
+
+```
+    {
+        "maven.terminal.customEnv": [
+            {
+                "environmentVariable": "MAVEN_OPTS",               // variable name
+                "value": "-Xms1024m -Xmx4096m"                     // value
+            },
+            {
+                "environmentVariable": "JAVA_HOME",                // variable name
+                "value": "C:\\Program Files\\Java\\jdk-9.0.4"      // value
+            }
+        ]
+    }
+```
+
+### Special Handling for JAVA_HOME
+
+If you have Red Hat's Java Language Support extension installed, then you can specify JAVA_HOME in settings for that extension:
+
+```
+    {
+        "java.home": "C:\\Program Files\\Java\\jdk-9.0.4"      // Red Hat Java Language Support Setting
+    }
+```
+
+This extension (Maven for Java) can reuse that setting if you desire:
+
+```
+    {
+        "maven.terminal.useJavaHome": true      // Use the Red Hat Java Language Support Setting for JAVA_HOME
+    }
+```
+
+With this support, you can specify JAVA_HOME in one place and you don't need to use the `maven.terminal.customEnv` setting unless
+you have other environment variables to set.
+
+If you have JAVA_HOME configured through the `maven.terminal.customEnv` setting, and also specify to reuse the Red Hat setting, then value from `maven.terminal.customEnv` will take precedent.
+
 ## Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/package.json
+++ b/package.json
@@ -293,6 +293,12 @@
             "default": "",
             "description": "Specifies absolute path of mvn executable.",
             "scope": "window"
+          },
+          "maven.set.javaHome": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+            "scope": "window"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -294,10 +294,10 @@
             "description": "Specifies absolute path of mvn executable.",
             "scope": "window"
           },
-          "maven.terminal.use.java.home": {
+          "maven.terminal.useJavaHome": {
             "type": "boolean",
             "default": false,
-            "description": "If true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+            "description": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
             "scope": "window"
           },
           "maven.terminal.customEnv": {
@@ -308,16 +308,16 @@
               "properties": {
                 "environmentVariable": {
                   "type": "string",
-                  "description": "environment variable to set"
+                  "description": "Name of the environment variable to set"
                 },
                 "value" : {
                   "type":"string",
-                  "description": "value for the variable"
+                  "description": "Value to set for the environment variable"
                 }
               }              
             },
             "default": [],
-            "description": "An array of environment settings.  These will be added to the terminal session before maven is first run",
+            "description": "Specifies an array of environment variable names and values. These environment variable values will be added to the terminal session before Maven is first executed.",
             "scope": "window"
           }
         }

--- a/package.json
+++ b/package.json
@@ -294,10 +294,30 @@
             "description": "Specifies absolute path of mvn executable.",
             "scope": "window"
           },
-          "maven.set.javaHome": {
+          "maven.terminal.use.java.home": {
             "type": "boolean",
             "default": false,
             "description": "If true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+            "scope": "window"
+          },
+          "maven.terminal.customEnv": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "environment setting",
+              "properties": {
+                "environmentVariable": {
+                  "type": "string",
+                  "description": "environment variable to set"
+                },
+                "value" : {
+                  "type":"string",
+                  "description": "value for the variable"
+                }
+              }              
+            },
+            "default": [],
+            "description": "An array of environment settings.  These will be added to the terminal session before maven is first run",
             "scope": "window"
           }
         }

--- a/src/VSCodeUI.ts
+++ b/src/VSCodeUI.ts
@@ -13,7 +13,7 @@ export namespace VSCodeUI {
         const { addNewLine, name, cwd } = Object.assign(defaultOptions, options);
         if (terminals[name] === undefined) {
             terminals[name] = window.createTerminal({ name });
-            setJavaHomeIfRequired(terminals[name]);
+            setupEnvironment(terminals[name]);
         }
         terminals[name].show();
         if (cwd) {
@@ -54,29 +54,44 @@ export namespace VSCodeUI {
         }
     }
 
-    export function setJavaHomeIfRequired(terminal: Terminal): void {
+    export function setupEnvironment(terminal: Terminal): void {
+        // do this first so it can be overridden if desired
+        setJavaHomeIfAvailable(terminal);
+
+        type EnvironmentSetting = {
+            environmentVariable: string;
+            value: string;
+        }
+
+        const environmentSettings: Array<EnvironmentSetting> = workspace.getConfiguration("maven").get("terminal.customEnv");
+        environmentSettings.forEach(s => {
+            terminal.sendText(getEnvironmentVariableCommand(s.environmentVariable, s.value), true);
+        });
+    }
+
+    export function setJavaHomeIfAvailable(terminal: Terminal): void {
         const javaHome: string = workspace.getConfiguration("java").get<string>("home");
-        const setJavaHome: boolean = workspace.getConfiguration("maven").get<boolean>("set.javaHome");
-        if (setJavaHome && javaHome) {
-            terminal.sendText(getJavaHomeCommand(javaHome), true);
+        const useJavaHome: boolean = workspace.getConfiguration("maven").get<boolean>("terminal.use.java.home");
+        if (useJavaHome && javaHome) {
+            terminal.sendText(getEnvironmentVariableCommand("JAVA_HOME", javaHome), true);
         }
     }
 
-    export function getJavaHomeCommand(javaHome: string): string {
+    export function getEnvironmentVariableCommand(variable: string, value: string): string {
         if (os.platform() === "win32") {
             const windowsShell: string = workspace.getConfiguration("terminal").get<string>("integrated.shell.windows")
                 .toLowerCase();
             if (windowsShell && windowsShell.indexOf("bash.exe") > -1 && windowsShell.indexOf("git") > -1) {
-                return `export JAVA_HOME="${javaHome}"`; // Git Bash
+                return `export ${variable}="${value}"`; // Git Bash
             } else if (windowsShell && windowsShell.indexOf("powershell.exe") > -1) {
-                return `$Env:JAVA_HOME="${javaHome}"`; // PowerShell
+                return `$Env:${variable}="${value}"`; // PowerShell
             } else if (windowsShell && windowsShell.indexOf("cmd.exe") > -1) {
-                return `set JAVA_HOME=${javaHome}`; // CMD
+                return `set ${variable}=${value}`; // CMD
             } else {
-                return `set JAVA_HOME=${javaHome}`; // Unknown, try using common one.
+                return `set ${variable}=${value}`; // Unknown, try using common one.
             }
         } else {
-            return `export JAVA_HOME="${javaHome}"`; // general linux
+            return `export ${variable}="${value}"`; // general linux
         }
     }
 

--- a/src/VSCodeUI.ts
+++ b/src/VSCodeUI.ts
@@ -54,7 +54,7 @@ export namespace VSCodeUI {
         }
     }
 
-    export function setJavaHomeIfRequired(terminal: Terminal) {
+    export function setJavaHomeIfRequired(terminal: Terminal): void {
         const javaHome: string = workspace.getConfiguration("java").get<string>("home");
         const setJavaHome: boolean = workspace.getConfiguration("maven").get<boolean>("set.javaHome");
         if (setJavaHome && javaHome) {

--- a/src/VSCodeUI.ts
+++ b/src/VSCodeUI.ts
@@ -61,10 +61,10 @@ export namespace VSCodeUI {
         type EnvironmentSetting = {
             environmentVariable: string;
             value: string;
-        }
+        };
 
-        const environmentSettings: Array<EnvironmentSetting> = workspace.getConfiguration("maven").get("terminal.customEnv");
-        environmentSettings.forEach(s => {
+        const environmentSettings: EnvironmentSetting[] = workspace.getConfiguration("maven").get("terminal.customEnv");
+        environmentSettings.forEach((s: EnvironmentSetting) => {
             terminal.sendText(getEnvironmentVariableCommand(s.environmentVariable, s.value), true);
         });
     }

--- a/src/VSCodeUI.ts
+++ b/src/VSCodeUI.ts
@@ -65,19 +65,21 @@ export namespace VSCodeUI {
 
         const environmentSettings: EnvironmentSetting[] = workspace.getConfiguration("maven").get("terminal.customEnv");
         environmentSettings.forEach((s: EnvironmentSetting) => {
-            terminal.sendText(getEnvironmentVariableCommand(s.environmentVariable, s.value), true);
+            terminal.sendText(composeSetEnvironmentVariableCommand(s.environmentVariable, s.value), true);
         });
     }
 
     export function setJavaHomeIfAvailable(terminal: Terminal): void {
+        // Look for the java.home setting from the redhat.java extension.  We can reuse it
+        // if it exists to avoid making the user configure it in two places.
         const javaHome: string = workspace.getConfiguration("java").get<string>("home");
-        const useJavaHome: boolean = workspace.getConfiguration("maven").get<boolean>("terminal.use.java.home");
+        const useJavaHome: boolean = workspace.getConfiguration("maven").get<boolean>("terminal.useJavaHome");
         if (useJavaHome && javaHome) {
-            terminal.sendText(getEnvironmentVariableCommand("JAVA_HOME", javaHome), true);
+            terminal.sendText(composeSetEnvironmentVariableCommand("JAVA_HOME", javaHome), true);
         }
     }
 
-    export function getEnvironmentVariableCommand(variable: string, value: string): string {
+    export function composeSetEnvironmentVariableCommand(variable: string, value: string): string {
         if (os.platform() === "win32") {
             const windowsShell: string = workspace.getConfiguration("terminal").get<string>("integrated.shell.windows")
                 .toLowerCase();


### PR DESCRIPTION
Currently, the maven integration only works if the JAVA_HOME environment variable is set permanently.  But setting JAVA_HOME permanently is inconvenient in many cases - especially if we are testing against many different versions of Java.

There is an existing configuration property in the VS Code Java support to configure JAVA_HOME - the "java.home" setting.

This PR adds a configuration property to the maven extension: "maven.set.javaHome".  If true, and if java.home is set, then the JAVA_HOME environment variable will be set to the configured value when a new terminal is opened.

I've tested this with Powershell, CMD, and GitBash and it works as expected.