### PR TITLE
for #67: fix for `mvnw --vesrion`

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -339,6 +339,7 @@ export namespace Utils {
         return new Promise<void>((resolve, reject) => {
             const customEnv: {} = VSCodeUI.setupEnvironment();
             const execOptions: child_process.ExecOptions = {
+                cwd: path.dirname(workspace.getConfiguration("maven.executable").get<string>("path") || ""), /* fix for `mvnw --version` */
                 env: Object.assign({}, process.env, customEnv)
             };
             child_process.exec(


### PR DESCRIPTION
#67 

`mvnw` will look for its .jar files recursively under current directory. Set `cwd` to ensure it works normally. 