### PR TITLE
fix bug of using `./mvnw` as maven executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to the "vscode-maven" extension will be documented in this f
 - [Change Log](#change-log)
     - [Unreleased](#unreleased)
     - [Released](#released)
+        - [0.9.2](#092)
+        - [0.9.1](#091)
         - [0.9.0](#090)
         - [0.8.0](#080)
         - [0.7.0](#070)
@@ -15,6 +17,9 @@ All notable changes to the "vscode-maven" extension will be documented in this f
 ## Unreleased
 
 ## Released
+### 0.9.2
+- Fixed bug of using `./mvnw` as maven executable.
+
 ### 0.9.1
 - Fetch list of popular archetypes on the fly. [#63](https://github.com/Microsoft/vscode-maven/pull/63)
 - Guide users to setup correct mvn executable path when error occurs. [#66](https://github.com/Microsoft/vscode-maven/pull/66)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-maven",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-maven",
   "displayName": "Maven for Java",
   "description": "Manage maven projects, execute goals, generate project from archetype, improve user experience for Java developers.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "icon": "resources/logo.png",
   "publisher": "vscjava",
   "aiKey": "7c4292ac-8ca8-4e02-9f1c-0b73e1eeeca4",
@@ -17,7 +17,7 @@
     "Maven",
     "Java"
   ],
-  "homepage": "https://github.com/Microsoft/vscode-maven/blob/v0.9.1/README.md",
+  "homepage": "https://github.com/Microsoft/vscode-maven/blob/v0.9.2/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/vscode-maven.git"

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -336,10 +336,20 @@ export namespace Utils {
     }
 
     export function getMavenVersion(): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
+        return new Promise<void>(async (resolve, reject) => {
             const customEnv: {} = VSCodeUI.setupEnvironment();
+            const mvnExecutablePath: string = workspace.getConfiguration("maven.executable").get<string>("path") || "mvn";
+            let mvnExecutableAbsolutePath: string = null;
+            if (workspace.workspaceFolders && workspace.workspaceFolders.length) {
+                for (const ws of workspace.workspaceFolders) {
+                    if (await fse.exists(path.resolve(ws.uri.fsPath, mvnExecutablePath))) {
+                        mvnExecutableAbsolutePath = path.resolve(ws.uri.fsPath, mvnExecutablePath);
+                        break;
+                    }
+                }
+            }
             const execOptions: child_process.ExecOptions = {
-                cwd: path.dirname(workspace.getConfiguration("maven.executable").get<string>("path") || ""), /* fix for `mvnw --version` */
+                cwd: mvnExecutableAbsolutePath && path.dirname(mvnExecutableAbsolutePath),
                 env: Object.assign({}, process.env, customEnv)
             };
             child_process.exec(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -339,7 +339,7 @@ export namespace Utils {
         return new Promise<void>(async (resolve, reject) => {
             const customEnv: {} = VSCodeUI.setupEnvironment();
             const mvnExecutablePath: string = workspace.getConfiguration("maven.executable").get<string>("path") || "mvn";
-            let mvnExecutableAbsolutePath: string = null;
+            let mvnExecutableAbsolutePath: string = mvnExecutablePath;
             if (workspace.workspaceFolders && workspace.workspaceFolders.length) {
                 for (const ws of workspace.workspaceFolders) {
                     if (await fse.exists(path.resolve(ws.uri.fsPath, mvnExecutablePath))) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,9 @@ export function deactivate(): void {
 // private helpers
 async function checkMavenAvailablility(): Promise<void> {
     try {
-        await Utils.getMavenVersion();
+        if (vscode.workspace.workspaceFolders) {
+            await Utils.getMavenVersion();
+        }
     } catch (error) {
         const OPTION_SHOW_FAQS: string = "Show FAQs";
         const OPTION_OPEN_SETTINGS: string = "Open Settings";


### PR DESCRIPTION
Test cases:
```    
    "maven.executable.path": "./mvnw",
    "maven.executable.path": "C:\\Users\\yanzh\\Desktop\\web5\\mvnw",
    "maven.executable.path": "",
```