### PR TITLE
Show Maven Projects Explorer only when extension is activated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Microsoft/vscode-maven.git"
   },
   "activationEvents": [
-    "workspaceContains:pom.xml",
+    "workspaceContains:**/pom.xml",
     "onCommand:maven.project.refreshAll",
     "onCommand:maven.goal.clean",
     "onCommand:maven.goal.validate",
@@ -139,7 +139,8 @@
       "explorer": [
         {
           "id": "mavenProjects",
-          "name": "Maven Projects"
+          "name": "Maven Projects",
+          "when": "mavenExtensionActivated"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         TelemetryWrapper.initilize(Utils.getExtensionPublisher(), Utils.getExtensionName(), Utils.getExtensionVersion(), Utils.getAiKey());
     }
 
+    vscode.commands.executeCommand("setContext", "mavenExtensionActivated", true);
+
     const mavenProjectsTreeDataProvider: ProjectDataProvider = new ProjectDataProvider(context);
     vscode.window.registerTreeDataProvider("mavenProjects", mavenProjectsTreeDataProvider);
 


### PR DESCRIPTION


In this PR: 
1. Activate extension if pom.xml found anywhere within the workspace (previously only under root folder)
2. Show maven projects explorer only when extension is activated. This solves issues: #36 #51 