### PR TITLE
refactor: maven command history

### DIFF
--- a/src/ICommandHistory.ts
+++ b/src/ICommandHistory.ts
@@ -1,0 +1,4 @@
+export interface ICommandHistory {
+    pomPath: string;
+    history: { command: string, timestamp: number }[];
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }));
 
     context.subscriptions.push(TelemetryWrapper.registerCommand("maven.history", async (item: MavenProjectNode | undefined) => {
-        await Utils.executeHistoricalGoals(item && item.pomPath);
+        if (item) {
+            await Utils.executeHistoricalGoals([item.pomPath]);
+        } else {
+            await Utils.executeHistoricalGoals(provider.mavenProjectNodes.map(_node => _node.pomPath));
+        }
     }));
 
     context.subscriptions.push(TelemetryWrapper.registerCommand("maven.goal.execute", async () => {


### PR DESCRIPTION
1. maven history commands are cached for each project in `path.join(os.tmpdir(), EXTENSION_NAME, md5(pomXmlFilePath), "commandHistory.json");`
2. The content is of the schema, command itself is used as key.
```
{
    pomPath: "<absolutePath>", 
    timestamps: { 
        "commandA":  <timestamp>,
        "commandB":  <timestamp>,
         .......
    }    
}
```