### PR TITLE
force to use mvn wrapper if found in workspace root folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
           "maven.executable.path": {
             "type": "string",
             "default": "",
-            "description": "Specifies absolute path of mvn executable if you don't have `mvn` in PATH. If a relative path is specified, the absolute path will be resolved from your workspace root folder.",
+            "description": "Specifies absolute path of mvn executable if you don't have `mvn` in PATH or `mvnw` in root folder. If a relative path is specified, the absolute path will be resolved from your workspace root folder.",
             "scope": "resource"
           },
           "maven.executable.options": {

--- a/package.json
+++ b/package.json
@@ -274,11 +274,6 @@
           "group": "1-lifecycle@90"
         },
         {
-          "command": "maven.project.openPom",
-          "when": "view == mavenProjects && viewItem == ProjectItem",
-          "group": "0-pom@0"
-        },
-        {
           "command": "maven.project.effectivePom",
           "when": "view == mavenProjects && viewItem == ProjectItem",
           "group": "0-pom@1"
@@ -303,7 +298,7 @@
           "maven.executable.path": {
             "type": "string",
             "default": "",
-            "description": "Specifies absolute path of mvn executable.",
+            "description": "Specifies absolute path of mvn executable if you don't have `mvn` in PATH. If a relative path is specified, the absolute path will be resolved from your workspace root folder.",
             "scope": "resource"
           },
           "maven.executable.options": {

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
             "type": "string",
             "default": "",
             "description": "Specifies absolute path of mvn executable.",
-            "scope": "window"
+            "scope": "resource"
           },
           "maven.executable.options": {
             "type": "string",

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -302,35 +302,7 @@ export namespace Utils {
             return filepath;
         }
     }
-/*
-    export function getMavenVersion(): Promise<void> {
-        return new Promise<void>(async (resolve, reject) => {
-            const customEnv: {} = VSCodeUI.setupEnvironment();
-            const mvnExecutablePath: string = getMaven();
-            let mvnExecutableAbsolutePath: string = mvnExecutablePath;
-            if (workspace.workspaceFolders && workspace.workspaceFolders.length) {
-                for (const ws of workspace.workspaceFolders) {
-                    if (await fse.pathExists(path.resolve(ws.uri.fsPath, mvnExecutablePath))) {
-                        mvnExecutableAbsolutePath = path.resolve(ws.uri.fsPath, mvnExecutablePath);
-                        break;
-                    }
-                }
-            }
-            const execOptions: child_process.ExecOptions = {
-                cwd: mvnExecutableAbsolutePath && path.dirname(mvnExecutableAbsolutePath),
-                env: Object.assign({}, process.env, customEnv)
-            };
-            child_process.exec(
-                `${Utils.getMavenExecutable()} --version`, execOptions, (error: Error, _stdout: string, _stderr: string): void => {
-                    if (error) {
-                        reject(error);
-                    } else {
-                        resolve();
-                    }
-                });
-        });
-    }
-*/
+
     export function getResourcePath(...args: string[]): string {
         return path.join(__filename, "..", "..", "resources", ...args);
     }

--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -152,7 +152,7 @@ export namespace ArchetypeModule {
 
     async function getLocalArchetypeItems(): Promise<Archetype[]> {
         const localCatalogPath: string = path.join(os.homedir(), ".m2", "repository", "archetype-catalog.xml");
-        if (await fse.exists(localCatalogPath)) {
+        if (await fse.pathExists(localCatalogPath)) {
             const buf: Buffer = await fse.readFile(localCatalogPath);
             return listArchetypeFromXml(buf.toString());
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,21 +113,32 @@ export function deactivate(): void {
 
 // private helpers
 async function checkMavenAvailablility(): Promise<void> {
-    try {
-        if (vscode.workspace.workspaceFolders) {
-            await Utils.getMavenVersion();
+    const workspaceFolders: vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders;
+    if (workspaceFolders && workspaceFolders.length) {
+        const errors: any = {};
+        for (const workspaceFolder of workspaceFolders) {
+            try {
+                const pomPaths: string[] = await Utils.getAllPomPaths(workspaceFolder);
+                if (pomPaths && pomPaths.length) {
+                    await Utils.executeInBackground("--version", null, workspaceFolder);
+                }
+            } catch (error) {
+                errors[workspaceFolder.name] = error;
+            }
         }
-    } catch (error) {
-        const OPTION_SHOW_FAQS: string = "Show FAQs";
-        const OPTION_OPEN_SETTINGS: string = "Open Settings";
-        const MESSAGE_MAVEN_ERROR: string = "Unable to execute Maven commands.";
-        const choiceForDetails: string = await vscode.window.showErrorMessage(`${MESSAGE_MAVEN_ERROR}\nError:\n${error.message}`, OPTION_OPEN_SETTINGS, OPTION_SHOW_FAQS);
-        if (choiceForDetails === OPTION_SHOW_FAQS) {
-            // open FAQs
-            const readmeFilePath: string = Utils.getPathToExtensionRoot("FAQs.md");
-            vscode.commands.executeCommand("markdown.showPreview", vscode.Uri.file(readmeFilePath));
-        } else if (choiceForDetails === OPTION_OPEN_SETTINGS) {
-            vscode.commands.executeCommand("workbench.action.openSettings");
+        if (Object.keys(errors).length > 0) {
+            const OPTION_SHOW_FAQS: string = "Show FAQs";
+            const OPTION_OPEN_SETTINGS: string = "Open Settings";
+            const MESSAGE_MAVEN_ERROR: string = "Unable to execute Maven commands.";
+            // TODO: show more detailed info. e.g. which workspace fail the command.
+            const choiceForDetails: string = await vscode.window.showErrorMessage(`${MESSAGE_MAVEN_ERROR}\n`, OPTION_OPEN_SETTINGS, OPTION_SHOW_FAQS);
+            if (choiceForDetails === OPTION_SHOW_FAQS) {
+                // open FAQs
+                const readmeFilePath: string = Utils.getPathToExtensionRoot("FAQs.md");
+                vscode.commands.executeCommand("markdown.showPreview", vscode.Uri.file(readmeFilePath));
+            } else if (choiceForDetails === OPTION_OPEN_SETTINGS) {
+                vscode.commands.executeCommand("workbench.action.openSettings");
+            }
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,9 +129,8 @@ async function checkMavenAvailablility(): Promise<void> {
         if (Object.keys(errors).length > 0) {
             const OPTION_SHOW_FAQS: string = "Show FAQs";
             const OPTION_OPEN_SETTINGS: string = "Open Settings";
-            const MESSAGE_MAVEN_ERROR: string = "Unable to execute Maven commands.";
-            // TODO: show more detailed info. e.g. which workspace fail the command.
-            const choiceForDetails: string = await vscode.window.showErrorMessage(`${MESSAGE_MAVEN_ERROR}\n`, OPTION_OPEN_SETTINGS, OPTION_SHOW_FAQS);
+            const errorMessage: string = `Unable to execute Maven commands for workspace folder [${Object.keys(errors).join(", ")}], please check your settings.`;
+            const choiceForDetails: string = await vscode.window.showErrorMessage(errorMessage, OPTION_OPEN_SETTINGS, OPTION_SHOW_FAQS);
             if (choiceForDetails === OPTION_SHOW_FAQS) {
                 // open FAQs
                 const readmeFilePath: string = Utils.getPathToExtensionRoot("FAQs.md");


### PR DESCRIPTION
Work item #84 .
1. allow to set different `maven.executable.path` for each workspace folder.  Related issue: #79 
2. check maven availability for each workspace folder if only `**/pom.xml` is found in it. 