### PR TITLE
fix warning: explicitly specify null for resource scope conf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha1-AlMyYjhrWmuaSXl9yC/v/fJpFAo=",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.46"
+                "@types/node": "*"
             }
         },
         "@types/md5": {
@@ -19,7 +19,7 @@
             "integrity": "sha1-k+I0N/zRenucqY0CqmAC6DWEL+g=",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.46"
+                "@types/node": "*"
             }
         },
         "@types/minimatch": {
@@ -46,7 +46,7 @@
             "integrity": "sha1-pLhLOHn/1HEJU/2Syr/emopOhFY=",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.46"
+                "@types/node": "*"
             }
         },
         "ajv": {
@@ -55,10 +55,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ansi-cyan": {
@@ -108,14 +108,14 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "arr-union": {
@@ -142,7 +142,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -180,8 +180,8 @@
             "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
             "integrity": "sha1-UbyV5BCVQX8zki+03uTyMrMiZIg=",
             "requires": {
-                "semver": "5.4.1",
-                "shimmer": "1.2.0"
+                "semver": "^5.3.0",
+                "shimmer": "^1.1.0"
             }
         },
         "asynckit": {
@@ -208,9 +208,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "balanced-match": {
@@ -225,7 +225,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "block-stream": {
@@ -234,7 +234,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "brace-expansion": {
@@ -242,7 +242,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -252,9 +252,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -293,11 +293,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "charenc": {
@@ -329,9 +329,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "co": {
@@ -346,7 +346,7 @@
             "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -361,7 +361,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -380,8 +380,8 @@
             "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
             "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
             "requires": {
-                "async-listener": "0.6.9",
-                "emitter-listener": "1.1.1"
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.1.1"
             }
         },
         "convert-source-map": {
@@ -407,13 +407,13 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -425,7 +425,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "delayed-stream": {
@@ -452,10 +452,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -465,7 +465,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "emitter-listener": {
@@ -473,7 +473,7 @@
             "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.1.tgz",
             "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
             "requires": {
-                "shimmer": "1.2.0"
+                "shimmer": "^1.2.0"
             }
         },
         "end-of-stream": {
@@ -482,7 +482,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -503,13 +503,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -518,7 +518,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -527,7 +527,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "extend": {
@@ -542,7 +542,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
         "extglob": {
@@ -551,7 +551,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -586,7 +586,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -601,11 +601,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "first-chunk-stream": {
@@ -626,7 +626,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -641,9 +641,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -657,9 +657,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
             "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -674,10 +674,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "getpass": {
@@ -686,7 +686,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -695,12 +695,12 @@
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -709,8 +709,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -719,7 +719,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -734,7 +734,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -745,8 +745,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -755,14 +755,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -771,11 +771,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -790,10 +790,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -808,8 +808,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -822,7 +822,7 @@
         "growl": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-            "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
             "dev": true
         },
         "gulp-chmod": {
@@ -831,9 +831,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -842,9 +842,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -853,8 +853,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -869,10 +869,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -887,8 +887,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -899,11 +899,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.87.0",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -924,12 +924,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -940,11 +940,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -965,8 +965,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -978,10 +978,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
@@ -990,11 +990,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1015,8 +1015,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1028,13 +1028,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -1052,10 +1052,10 @@
                 "queue": {
                     "version": "4.4.2",
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
-                    "integrity": "sha1-Wpcz2ai4vRs26TS8nFWribKOKcc=",
+                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "vinyl": {
@@ -1064,12 +1064,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1086,8 +1086,8 @@
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -1096,7 +1096,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1117,9 +1117,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1128,8 +1128,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1161,7 +1161,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1182,7 +1182,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-number": {
@@ -1191,7 +1191,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1200,7 +1200,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1299,7 +1299,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1313,7 +1313,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -1346,7 +1346,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lodash.isequal": {
@@ -1372,9 +1372,9 @@
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
             "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
             "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "1.1.6"
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
             }
         },
         "merge-stream": {
@@ -1383,7 +1383,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -1392,19 +1392,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1413,7 +1413,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -1428,7 +1428,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1437,7 +1437,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1454,7 +1454,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "minimatch": {
@@ -1462,7 +1462,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1504,7 +1504,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -1521,10 +1521,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "node.extend": {
@@ -1533,7 +1533,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -1542,7 +1542,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "oauth-sign": {
@@ -1563,8 +1563,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -1573,7 +1573,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "ordered-read-streams": {
@@ -1582,8 +1582,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "parse-glob": {
@@ -1592,10 +1592,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1610,7 +1610,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1639,7 +1639,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -1660,11 +1660,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "preserve": {
@@ -1703,7 +1703,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -1712,9 +1712,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -1737,22 +1737,22 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -1785,26 +1785,26 @@
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             }
         },
         "requires-port": {
@@ -1819,16 +1819,16 @@
             "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -1855,7 +1855,7 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true
         },
         "source-map-support": {
@@ -1864,8 +1864,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "split": {
@@ -1874,7 +1874,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
@@ -1883,14 +1883,14 @@
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -1905,7 +1905,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -1920,7 +1920,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -1935,7 +1935,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -1944,7 +1944,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -1953,7 +1953,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -1962,8 +1962,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "supports-color": {
@@ -1978,9 +1978,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -1995,8 +1995,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -2005,8 +2005,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "to-absolute-glob": {
@@ -2015,7 +2015,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2024,7 +2024,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -2035,7 +2035,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tslib": {
@@ -2050,17 +2050,17 @@
             "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.3.0",
-                "commander": "2.11.0",
-                "diff": "3.3.1",
-                "glob": "7.1.2",
-                "minimatch": "3.0.4",
-                "resolve": "1.5.0",
-                "semver": "5.4.1",
-                "tslib": "1.8.0",
-                "tsutils": "2.13.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.1.0",
+                "commander": "^2.9.0",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.7.1",
+                "tsutils": "^2.12.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2069,7 +2069,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -2078,9 +2078,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "supports-color": {
@@ -2089,7 +2089,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -2100,7 +2100,7 @@
             "integrity": "sha1-Mo7pwo0HzfeTKTIEyW4v+rkiGZQ=",
             "dev": true,
             "requires": {
-                "tsutils": "1.9.1"
+                "tsutils": "^1.4.0"
             },
             "dependencies": {
                 "tsutils": {
@@ -2117,7 +2117,7 @@
             "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
             "dev": true,
             "requires": {
-                "tslib": "1.8.0"
+                "tslib": "^1.7.1"
             }
         },
         "tunnel-agent": {
@@ -2126,7 +2126,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -2148,8 +2148,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "universalify": {
@@ -2163,8 +2163,8 @@
             "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -2190,9 +2190,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -2201,8 +2201,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -2211,23 +2211,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -2248,8 +2248,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2261,8 +2261,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vscode": {
@@ -2271,20 +2271,20 @@
             "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.87.0",
-                "semver": "5.4.1",
-                "source-map-support": "0.5.6",
-                "url-parse": "1.4.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "vscode-extension-telemetry": {
@@ -2301,9 +2301,9 @@
             "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.2.1.tgz",
             "integrity": "sha512-rIri4xyBHAT6/8zXNQTsaXNioiY+3ibiRGTSxKXDOU111h5Ieuhsaxpuzl1hhNjc4JcDJ9k4+bQCgCbTut+V4w==",
             "requires": {
-                "continuation-local-storage": "3.2.1",
-                "fs-extra": "5.0.0",
-                "uuid": "3.1.0",
+                "continuation-local-storage": "^3.2.1",
+                "fs-extra": "^5.0.0",
+                "uuid": "^3.1.0",
                 "vscode-extension-telemetry": "0.0.10"
             },
             "dependencies": {
@@ -2312,9 +2312,9 @@
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
                     "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 }
             }
@@ -2335,8 +2335,8 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
             "requires": {
-                "sax": "1.2.4",
-                "xmlbuilder": "9.0.4"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
             }
         },
         "xmlbuilder": {
@@ -2356,8 +2356,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -2366,7 +2366,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -14,7 +14,7 @@ export namespace Settings {
         }
     }
 
-    export function excludedFolders(resource?: Uri): string[] {
+    export function excludedFolders(resource: Uri): string[] {
         return _getMavenSection("excludedFolders", resource);
     }
 
@@ -31,15 +31,15 @@ export namespace Settings {
         }
     }
     export namespace Executable {
-        export function path(resource?: Uri): string {
+        export function path(resource: Uri): string {
             return _getMavenSection("executable.path", resource);
         }
-        export function options(resource?: Uri): string {
+        export function options(resource: Uri): string {
             return _getMavenSection("executable.options", resource);
         }
     }
 
     function _getMavenSection<T>(section: string, resource?: Uri): T {
-        return workspace.getConfiguration("maven", resource || null).get<T>(section);
+        return workspace.getConfiguration("maven", resource).get<T>(section);
     }
 }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -40,6 +40,6 @@ export namespace Settings {
     }
 
     function _getMavenSection<T>(section: string, resource?: Uri): T {
-        return workspace.getConfiguration("maven", resource).get<T>(section);
+        return workspace.getConfiguration("maven", resource || null).get<T>(section);
     }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -152,7 +152,7 @@ export namespace Utils {
 
     async function getMaven(workspaceFolder?: WorkspaceFolder): Promise<string> {
         if (!workspaceFolder) {
-            return Settings.Executable.path() || "mvn";
+            return Settings.Executable.path(null) || "mvn";
         }
         const executablePathInConf: string = Settings.Executable.path(workspaceFolder.uri);
         if (!executablePathInConf) {


### PR DESCRIPTION
To fix warining message

Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for 'maven.executable.path', provide the URI of a resource or 'null' for any resource.