### PR TITLE
Sort maven project list in Explorer and hide invalid pom.xml files

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -259,7 +259,7 @@ export namespace Utils {
     }
 
     export function currentWindowsShell(): string {
-        const is32ProcessOn64Windows: string = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+        const is32ProcessOn64Windows: boolean = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
         const system32Path: string = `${process.env.windir}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}`;
         const expectedLocations: { [shell: string]: string[] } = {
             'Command Prompt': [`${system32Path}\\cmd.exe`],

--- a/src/explorer/model/MavenProjectNode.ts
+++ b/src/explorer/model/MavenProjectNode.ts
@@ -18,7 +18,7 @@ export class MavenProjectNode extends NodeBase {
     }
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
-        await this._ensureMavenProjectParsed();
+        await this.ensureMavenProjectParsed();
         const treeItem: vscode.TreeItem = new vscode.TreeItem(this._mavenProject.name);
         treeItem.iconPath = {
             light: Utils.getResourcePath("project.svg"),
@@ -53,7 +53,7 @@ export class MavenProjectNode extends NodeBase {
         return this._mavenProject.modules.length > 0;
     }
 
-    private async _ensureMavenProjectParsed(): Promise<void> {
+    public async ensureMavenProjectParsed(): Promise<void> {
         if (!this._mavenProject) {
             const pom: {} = await Utils.parseXmlFile(this._pomPath);
             this._mavenProject = new MavenProject(pom);

--- a/src/explorer/model/MavenProjectNode.ts
+++ b/src/explorer/model/MavenProjectNode.ts
@@ -19,6 +19,7 @@ export class MavenProjectNode extends NodeBase {
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
         await this.ensureMavenProjectParsed();
+
         const treeItem: vscode.TreeItem = new vscode.TreeItem(this._mavenProject.name);
         treeItem.iconPath = {
             light: Utils.getResourcePath("project.svg"),
@@ -49,14 +50,24 @@ export class MavenProjectNode extends NodeBase {
     public get mavenProject(): MavenProject {
         return this._mavenProject;
     }
+
+    public async isValidPom(): Promise<boolean> {
+        await this.ensureMavenProjectParsed();
+        return !!this._mavenProject;
+    }
+
     private get _hasModules(): boolean {
         return this._mavenProject.modules.length > 0;
     }
 
     public async ensureMavenProjectParsed(): Promise<void> {
         if (!this._mavenProject) {
-            const pom: {} = await Utils.parseXmlFile(this._pomPath);
-            this._mavenProject = new MavenProject(pom);
+            try {
+                const pom: {} = await Utils.parseXmlFile(this._pomPath);
+                this._mavenProject = new MavenProject(pom);
+            } catch (error) {
+                // Error parsing pom.xml file
+            }
         }
     }
 }

--- a/src/explorer/model/MavenProjectNode.ts
+++ b/src/explorer/model/MavenProjectNode.ts
@@ -18,7 +18,9 @@ export class MavenProjectNode extends NodeBase {
     }
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
-        await this.ensureMavenProjectParsed();
+        if (! await this.hasValidPom()) {
+            return undefined;
+        }
 
         const treeItem: vscode.TreeItem = new vscode.TreeItem(this._mavenProject.name);
         treeItem.iconPath = {
@@ -29,7 +31,6 @@ export class MavenProjectNode extends NodeBase {
         treeItem.collapsibleState = this._hasModules ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
         treeItem.command = { title: "open pom", command: "maven.project.openPom", arguments: [this] };
         return treeItem;
-
     }
 
     public getChildren(): vscode.ProviderResult<NodeBase[]> {
@@ -51,8 +52,8 @@ export class MavenProjectNode extends NodeBase {
         return this._mavenProject;
     }
 
-    public async isValidPom(): Promise<boolean> {
-        await this.ensureMavenProjectParsed();
+    public async hasValidPom(): Promise<boolean> {
+        await this._parseMavenProject();
         return !!this._mavenProject;
     }
 
@@ -60,7 +61,7 @@ export class MavenProjectNode extends NodeBase {
         return this._mavenProject.modules.length > 0;
     }
 
-    public async ensureMavenProjectParsed(): Promise<void> {
+    private async _parseMavenProject(): Promise<void> {
         if (!this._mavenProject) {
             try {
                 const pom: {} = await Utils.parseXmlFile(this._pomPath);

--- a/src/explorer/model/WorkspaceFolderNode.ts
+++ b/src/explorer/model/WorkspaceFolderNode.ts
@@ -33,12 +33,12 @@ export class WorkspaceFolderNode extends NodeBase {
         for ( const pomPath of this._pomPaths ) {
             const projectNode: MavenProjectNode = new MavenProjectNode(pomPath);
 
-            if ( await projectNode.isValidPom() ) {
+            if ( await projectNode.hasValidPom() ) {
                 this._children.push(projectNode);
             }
         }
 
-        await this._sortChildren();
+        this._sortChildren();
         return this._children;
     }
 
@@ -50,7 +50,7 @@ export class WorkspaceFolderNode extends NodeBase {
         this._pomPaths = await Utils.getAllPomPaths(this._workspaceFolder);
     }
 
-    private async _sortChildren(): Promise<void> {
+    private _sortChildren(): void {
         this._children.sort( (a, b) => {
             return  a.mavenProject.name > b.mavenProject.name ? 1 : a.mavenProject.name < b.mavenProject.name ? -1 : 0;
         } );

--- a/src/explorer/model/WorkspaceFolderNode.ts
+++ b/src/explorer/model/WorkspaceFolderNode.ts
@@ -29,6 +29,7 @@ export class WorkspaceFolderNode extends NodeBase {
     public async getChildren(): Promise<NodeBase[]> {
         await this._searchForPomPaths();
         this._children = this._pomPaths.map(pomPath => new MavenProjectNode(pomPath));
+        await this._sortChildren();
         return this._children;
     }
 
@@ -38,5 +39,14 @@ export class WorkspaceFolderNode extends NodeBase {
 
     private async _searchForPomPaths(): Promise<void> {
         this._pomPaths = await Utils.getAllPomPaths(this._workspaceFolder);
+    }
+
+    private async _sortChildren(): Promise<void> {
+        for ( const projectNode of this._children ) {
+            await projectNode.ensureMavenProjectParsed();
+        }
+        this._children.sort( (a, b) => {
+            return  a.mavenProject.name > b.mavenProject.name ? 1 : a.mavenProject.name < b.mavenProject.name ? -1 : 0;
+        } );
     }
 }

--- a/src/explorer/model/WorkspaceFolderNode.ts
+++ b/src/explorer/model/WorkspaceFolderNode.ts
@@ -28,7 +28,16 @@ export class WorkspaceFolderNode extends NodeBase {
 
     public async getChildren(): Promise<NodeBase[]> {
         await this._searchForPomPaths();
-        this._children = this._pomPaths.map(pomPath => new MavenProjectNode(pomPath));
+        this._children = [];
+
+        for ( const pomPath of this._pomPaths ) {
+            const projectNode: MavenProjectNode = new MavenProjectNode(pomPath);
+
+            if ( await projectNode.isValidPom() ) {
+                this._children.push(projectNode);
+            }
+        }
+
         await this._sortChildren();
         return this._children;
     }
@@ -42,9 +51,6 @@ export class WorkspaceFolderNode extends NodeBase {
     }
 
     private async _sortChildren(): Promise<void> {
-        for ( const projectNode of this._children ) {
-            await projectNode.ensureMavenProjectParsed();
-        }
         this._children.sort( (a, b) => {
             return  a.mavenProject.name > b.mavenProject.name ? 1 : a.mavenProject.name < b.mavenProject.name ? -1 : 0;
         } );


### PR DESCRIPTION
- Fixed a TS typing error on a boolean variable.
- Updated `_ensureMavenProjectParsed` of `MavenProjectNode` to become public.
- Alphabetically sort the array of `MavenProjectNode` items in `WorkspaceFolderNode`.

<img width="376" alt="screen shot 2018-08-31 at 6 21 31 pm" src="https://user-images.githubusercontent.com/791222/44940390-08683680-ad4b-11e8-8378-bb4583ffd030.png">

If I've made any mistakes or if there is a better way of approaching the problem, please let me know.
