### PR TITLE
Remove unused activation event.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "onCommand:maven.project.openPom",
     "onCommand:maven.archetype.generate",
     "onCommand:maven.archetype.update",
-    "onCommand:maven.history",
-    "onView:mavenProjects"
+    "onCommand:maven.history"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
This explorer never shows before extension activation. So you can never activate the extension "onView" the explorer. 🤣 

```jsonc
"views": {
      "explorer": [
        {
          "id": "mavenProjects",
          "name": "Maven Projects",
          "when": "mavenExtensionActivated"
        }
      ]
    },
```