### PR TITLE
Update version of telemetry wrapper.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,9 +2336,9 @@
             }
         },
         "vscode-extension-telemetry-wrapper": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.3.0.tgz",
-            "integrity": "sha512-VBHBnQR1rkdtxyFPntPafrHdeQ8sQAzaomtgsgJnW+TiLIEJDmkxrWVH5/6wHp/e0d7/M5nnsb+TAEUa2j6n/w==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.3.1.tgz",
+            "integrity": "sha512-92OsAerFwbMf5XzrkWROuehf8tZ25GdLOC7DpvMVXtDO+arFMM0ciBUW9V7KFf5MKCnS+CaxdUvOAV2Ozhgscw==",
             "requires": {
                 "continuation-local-storage": "^3.2.1",
                 "fs-extra": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -368,7 +368,7 @@
     "fs-extra": "^4.0.3",
     "md5": "^2.2.1",
     "minimatch": "^3.0.4",
-    "vscode-extension-telemetry-wrapper": "^0.3.0",
+    "vscode-extension-telemetry-wrapper": "^0.3.1",
     "xml2js": "^0.4.19"
   }
 }


### PR DESCRIPTION
Update the patch version. In `0.3.1` **OperationalError** is renamed to **OperationError**. Here in this repo we are not using it, so not code changes except the version. 