### PR TITLE
Use globalState to cache plugin info.

### DIFF
--- a/src/explorer/PluginInfoProvider.ts
+++ b/src/explorer/PluginInfoProvider.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as _ from "lodash";
+import * as vscode from "vscode";
+import { Utils } from "../Utils";
+
+const KEY_PLUGINS: string = "plugins";
+
+interface IPluginInfo {
+    prefix?: string;
+    goals?: string[];
+}
+
+class PluginInfoProvider {
+    private _context: vscode.ExtensionContext;
+
+    public initialize(context: vscode.ExtensionContext): void {
+        this._context = context;
+    }
+
+    public async getPluginInfo(projectBasePath: string, gid: string, aid: string, version: string): Promise<IPluginInfo> {
+        const cachedResult: IPluginInfo = await this.getFromLocalCache(gid, aid, version);
+        if (cachedResult) {
+            return cachedResult;
+        }
+
+        const latestResult: IPluginInfo = await this.fetchFromRepository(projectBasePath, gid, aid, version);
+        await this.saveToLocalCache(gid, aid, version, latestResult);
+        return latestResult;
+    }
+
+    private async getFromLocalCache(gid: string, aid: string, version: string): Promise<IPluginInfo> {
+        const plugins: any = this._context.globalState.get(KEY_PLUGINS);
+        return _.get(plugins, [gid, aid, version]);
+    }
+
+    private async saveToLocalCache(gid: string, aid: string, version: string, pluginInfo: IPluginInfo): Promise<void> {
+        let plugins: any = this._context.globalState.get(KEY_PLUGINS);
+        if (!plugins) {
+            plugins = {};
+        }
+        if (!plugins[gid]) {
+            plugins[gid] = {};
+        }
+        if (!plugins[gid][aid]) {
+            plugins[gid][aid] = {};
+        }
+        plugins[gid][aid][version] = pluginInfo;
+        await this._context.globalState.update(KEY_PLUGINS, plugins);
+    }
+
+    private async fetchFromRepository(projectBasePath: string, gid: string, aid: string, version?: string): Promise<IPluginInfo> {
+        let prefix: string;
+        const goals: string[] = [];
+        const rawOutput: string = await Utils.getPluginDescription(this.pluginId(gid, aid, version), projectBasePath);
+
+        const versionRegExp: RegExp = /^Version: (.*)/m;
+        const versionMatch: string[] = rawOutput.match(versionRegExp);
+        if (versionMatch && versionMatch.length === 2) {
+            version = versionMatch[1];
+        }
+
+        // find prefix
+        const prefixRegExp: RegExp = /^Goal Prefix: (.*)/m;
+        const prefixMatch: string[] = rawOutput.match(prefixRegExp);
+        if (prefixMatch && prefixMatch.length === 2) {
+            prefix = prefixMatch[1];
+        }
+
+        // find goals
+        if (version && prefix) {
+            const goalRegExp: RegExp = new RegExp(`^${prefix}:(.*)`, "gm");
+            const goalsMatch: string[] = rawOutput.match(goalRegExp);
+            if (goalsMatch) {
+                goals.push(...goalsMatch);
+            }
+        }
+
+        return { prefix, goals };
+    }
+
+    private pluginId(gid: string, aid: string, version?: string): string {
+        return `${gid}:${aid}${version ? `:${version}` : ""}`;
+    }
+}
+
+// tslint:disable-next-line:export-name
+export const pluginInfoProvider: PluginInfoProvider = new PluginInfoProvider();

--- a/src/explorer/model/MavenPlugin.ts
+++ b/src/explorer/model/MavenPlugin.ts
@@ -4,7 +4,7 @@
 import * as vscode from "vscode";
 import { Utils } from "../../Utils";
 import { mavenExplorerProvider } from "../MavenExplorerProvider";
-import { pluginInfoProvider } from "../PluginInfoProvider";
+import { pluginInfoProvider } from "../pluginInfoProvider";
 import { ITreeItem } from "./ITreeItem";
 import { MavenProject } from "./MavenProject";
 import { PluginGoal } from "./PluginGoal";

--- a/src/explorer/pluginInfoProvider.ts
+++ b/src/explorer/pluginInfoProvider.ts
@@ -53,7 +53,7 @@ class PluginInfoProvider {
     private async fetchFromRepository(projectBasePath: string, gid: string, aid: string, version?: string): Promise<IPluginInfo> {
         let prefix: string;
         const goals: string[] = [];
-        const rawOutput: string = await Utils.getPluginDescription(this.pluginId(gid, aid, version), projectBasePath);
+        const rawOutput: string = await Utils.getPluginDescription(this.getPluginId(gid, aid, version), projectBasePath);
 
         const versionRegExp: RegExp = /^Version: (.*)/m;
         const versionMatch: string[] = rawOutput.match(versionRegExp);
@@ -80,10 +80,9 @@ class PluginInfoProvider {
         return { prefix, goals };
     }
 
-    private pluginId(gid: string, aid: string, version?: string): string {
+    private getPluginId(gid: string, aid: string, version?: string): string {
         return `${gid}:${aid}${version ? `:${version}` : ""}`;
     }
 }
 
-// tslint:disable-next-line:export-name
 export const pluginInfoProvider: PluginInfoProvider = new PluginInfoProvider();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { mavenExplorerProvider } from "./explorer/MavenExplorerProvider";
 import { ITreeItem } from "./explorer/model/ITreeItem";
 import { MavenProject } from "./explorer/model/MavenProject";
 import { PluginGoal } from "./explorer/model/PluginGoal";
-import { pluginInfoProvider } from "./explorer/PluginInfoProvider";
+import { pluginInfoProvider } from "./explorer/pluginInfoProvider";
 import { Settings } from "./Settings";
 import { Utils } from "./Utils";
 import { VSCodeUI } from "./VSCodeUI";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { mavenExplorerProvider } from "./explorer/MavenExplorerProvider";
 import { ITreeItem } from "./explorer/model/ITreeItem";
 import { MavenProject } from "./explorer/model/MavenProject";
 import { PluginGoal } from "./explorer/model/PluginGoal";
+import { pluginInfoProvider } from "./explorer/PluginInfoProvider";
 import { Settings } from "./Settings";
 import { Utils } from "./Utils";
 import { VSCodeUI } from "./VSCodeUI";
@@ -49,7 +50,7 @@ function registerCommand(context: vscode.ExtensionContext, commandName: string, 
 
 async function doActivate(_operationId: string, context: vscode.ExtensionContext): Promise<void> {
     await vscode.commands.executeCommand("setContext", "mavenExtensionActivated", true);
-
+    pluginInfoProvider.initialize(context);
     context.subscriptions.push(vscode.window.registerTreeDataProvider("mavenProjects", mavenExplorerProvider));
 
     // pom.xml listener to refresh tree view


### PR DESCRIPTION
Use a `PluginInfoProvider` to get detailed info of a maven plugin, e.g. prefix, goals.

It uses the `ExtensionContext.globalState` as the cache to improve perf. 
