### PR TITLE
Do not calculated effective-pom on refreshing a collapsed project.

### DIFF
--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -106,7 +106,7 @@ export class MavenProject implements ITreeItem {
 
     public async refresh(): Promise<void> {
         await this.refreshPom();
-        await this.calculateEffectivePom(true);
+        this._rawEffectivePom = undefined;
     }
 
     public async parsePom(): Promise<void> {


### PR DESCRIPTION
See: #182 

In this PR, when adding/modifying a pom.xml in current workspace, `refresh` is triggered:
* if the project is collapsed: only parse the pom and update the label with latest artifact id. 
* if the project is expanded: it calls `getChildren` automatically, where effective pom is calculated if missing. 