### PR TITLE
Add onView activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "onCommand:maven.archetype.generate",
     "onCommand:maven.archetype.update",
     "onCommand:maven.history",
-    "onCommand:maven.plugin.execute"
+    "onCommand:maven.plugin.execute",
+    "onView:mavenProjects"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -146,8 +147,7 @@
       "explorer": [
         {
           "id": "mavenProjects",
-          "name": "%contributes.views.explorer.mavenProjects%",
-          "when": "mavenExtensionActivated"
+          "name": "%contributes.views.explorer.mavenProjects%"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,6 @@ function registerCommand(context: vscode.ExtensionContext, commandName: string, 
 }
 
 async function doActivate(_operationId: string, context: vscode.ExtensionContext): Promise<void> {
-    await vscode.commands.executeCommand("setContext", "mavenExtensionActivated", true);
     pluginInfoProvider.initialize(context);
     context.subscriptions.push(vscode.window.registerTreeDataProvider("mavenProjects", mavenExplorerProvider));
 


### PR DESCRIPTION
Previously to avoid noise, we only show the explorer if a pom.xml file is found in the workspace.
For new users, if no workspace folder is open, it's hard to find the explorer after installation.  


