### PR TITLE
Remove outdated telemetry events

### DIFF
--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -5,7 +5,7 @@ import * as fse from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import { Uri } from "vscode";
-import { instrumentOperationStep, sendInfo, Session, TelemetryWrapper } from "vscode-extension-telemetry-wrapper";
+import { instrumentOperationStep, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { OperationCanceledError } from "../Errors";
 import { getPathToExtensionRoot } from "../utils/contextUtils";
 import { Utils } from "../utils/Utils";
@@ -15,51 +15,15 @@ import { Archetype } from "./Archetype";
 const REMOTE_ARCHETYPE_CATALOG_URL: string = "https://repo.maven.apache.org/maven2/archetype-catalog.xml";
 const POPULAR_ARCHETYPES_URL: string = "https://vscodemaventelemetry.blob.core.windows.net/public/popular_archetypes.json";
 
-// TO REMOVE
-class Step {
-    public readonly name: string;
-    public readonly info: string;
-    constructor(name: string, info: string) {
-        this.name = name;
-        this.info = info;
-    }
-}
-
-const stepTargetFolder: Step = new Step("TargetFolder", "Target folder selected.");
-const stepListMore: Step = new Step("ListMore", "All archetypes listed.");
-const stepArchetype: Step = new Step("Archetype", "Archetype selected.");
-
-function finishStep(step: Step): void {
-    const session: Session = TelemetryWrapper.currentSession();
-    if (session && session.extraProperties) {
-        if (!session.extraProperties.finishedSteps) {
-            session.extraProperties.finishedSteps = [];
-        }
-        session.extraProperties.finishedSteps.push(step.name);
-    }
-    TelemetryWrapper.info(step.info);
-}
-
-// UNTIL HERE
 export namespace ArchetypeModule {
     async function selectArchetype(): Promise<Archetype> {
         let selectedArchetype: Archetype = await showQuickPickForArchetypes();
         if (selectedArchetype && !selectedArchetype.artifactId) {
-            finishStep(stepListMore);
             selectedArchetype = await showQuickPickForArchetypes({ all: true });
         }
         if (!selectedArchetype) {
             throw new OperationCanceledError("Archeype not selected.");
         }
-        // TO REMOVE
-        const { artifactId, groupId } = selectedArchetype;
-        const session: Session = TelemetryWrapper.currentSession();
-        if (session && session.extraProperties) {
-            session.extraProperties.artifactId = artifactId;
-            session.extraProperties.groupId = groupId;
-        }
-        finishStep(stepArchetype);
-        // UNTIL HERE
 
         return selectedArchetype;
     }
@@ -73,9 +37,6 @@ export namespace ArchetypeModule {
         if (!cwd) {
             throw new OperationCanceledError("Target folder not selected.");
         }
-        // TO REMOVE
-        finishStep(stepTargetFolder);
-        // UNTIL HERE
         return cwd;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@
 "use strict";
 import * as vscode from "vscode";
 import { Progress, Uri } from "vscode";
-import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation, TelemetryWrapper } from "vscode-extension-telemetry-wrapper";
+import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import { ArchetypeModule } from "./archetype/ArchetypeModule";
 import { completionProvider } from "./completionProvider";
 import { OperationCanceledError } from "./Errors";
@@ -17,7 +17,7 @@ import { mavenOutputChannel } from "./mavenOutputChannel";
 import { mavenTerminal } from "./mavenTerminal";
 import { Settings } from "./Settings";
 import { taskExecutor } from "./taskExecutor";
-import { getAiKey, getExtensionId, getExtensionName, getExtensionPublisher, getExtensionVersion, loadPackageInfo } from "./utils/contextUtils";
+import { getAiKey, getExtensionId, getExtensionVersion, loadPackageInfo } from "./utils/contextUtils";
 import { Utils } from "./utils/Utils";
 import { VSCodeUI } from "./VSCodeUI";
 
@@ -25,7 +25,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     await loadPackageInfo(context);
     // Usage data statistics.
     if (getAiKey()) {
-        TelemetryWrapper.initilize(getExtensionPublisher(), getExtensionName(), getExtensionVersion(), getAiKey());
         await initialize(getExtensionId(), getExtensionVersion(), getAiKey());
     }
     await instrumentOperation("activation", doActivate)(context);
@@ -48,9 +47,7 @@ function registerCommand(context: vscode.ExtensionContext, commandName: string, 
             throw error;
         }
     });
-    // tslint:disable-next-line:no-suspicious-comment
-    // TODO: replace TelemetryWrapper.registerCommand with vscode.commands.registerCommand.
-    context.subscriptions.push(TelemetryWrapper.registerCommand(commandName, callbackWithTroubleshooting));
+    context.subscriptions.push(vscode.commands.registerCommand(commandName, callbackWithTroubleshooting));
 }
 
 async function doActivate(_operationId: string, context: vscode.ExtensionContext): Promise<void> {


### PR DESCRIPTION
Old API uses `continuous-storage` which is not robust enough. Retire it now. 