### PR TITLE
Retrieve completion items from local Maven repository on the fly

### DIFF
--- a/package.json
+++ b/package.json
@@ -398,12 +398,6 @@
             "description": "%configuration.maven.terminal.customEnv%",
             "scope": "window"
           },
-          "maven.completion.local.enabled": {
-            "type": "boolean",
-            "default": false,
-            "scope": "window",
-            "description": "%configuration.maven.local.completion.enabled%"
-          },
           "maven.view": {
             "type": "string",
             "enum": [
@@ -411,7 +405,7 @@
               "hierarchical"
             ],
             "default": "flat",
-            "scope": "resourec",
+            "scope": "resource",
             "description": "%configuration.maven.view%"
           }
         }

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,14 +12,13 @@
     "contributes.commands.maven.view.hierarchical": "Switch to hierarchical view",
     "contributes.commands.maven.view.flat": "Switch to flat view",
     "contributes.views.explorer.mavenProjects": "Maven Projects",
-    "configuration.maven.excludedFolders": "Specifies filepath pattern of folders to exclude while searching for Maven projects.",
-    "configuration.maven.executable.preferMavenWrapper": "Specifies whether you prefer to use Maven wrapper. If true, it tries using 'mvnw' in root folder by default if the file econfiguration.xists. Otherwise it tries 'mvn' in PATH instead.",
-    "configuration.maven.executable.path": "Specifies absolute path of your mvn executable. When this value is empty, it tries using 'mvn' or 'mvnw' according to value of 'maven.executeble.preferMavenWapper'. Note that a relative path is not suggested, but if you do specify one, the absolute path will be resolved from your workspace root folder (if exists). ",
+    "configuration.maven.excludedFolders": "Specifies file path pattern of folders to exclude while searching for Maven projects.",
+    "configuration.maven.executable.preferMavenWrapper": "Specifies whether you prefer to use Maven wrapper. If true, it tries using 'mvnw' in root folder by default if the file configuration exists. Otherwise it tries 'mvn' in PATH instead.",
+    "configuration.maven.executable.path": "Specifies absolute path of your mvn executable. When this value is empty, it tries using 'mvn' or 'mvnw' according to value of 'maven.executable.preferMavenWrapper'. Note that a relative path is not suggested, but if you do specify one, the absolute path will be resolved from your workspace root folder (if exists). ",
     "configuration.maven.executable.options": "Specifies default options for all mvn commands.",
     "configuration.maven.terminal.useJavaHome": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
     "configuration.maven.terminal.customEnv": "Specifies an array of environment variable names and values. These environment variable values will be added to the terminal session before Maven is first executed.",
     "configuration.maven.terminal.customEnv.environmentVariable": "Name of the environment variable to set.",
     "configuration.maven.terminal.customEnv.value": "Value of the environment variable to set.",
-    "configuration.maven.completion.local.enabled": "Specifies whether to index local Maven repository for POM completion. (Reload Window to take effect, indexing takes time according to the size of your repository)",
     "configuration.maven.view": "Specifies the way of viewing Maven projects."
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -14,12 +14,11 @@
     "contributes.views.explorer.mavenProjects": "Maven 项目",
     "configuration.maven.excludedFolders": "指定搜索 Maven 项目时要排除的文件夹。",
     "configuration.maven.executable.preferMavenWrapper": "指定是否优先使用 Maven Wrapper。如果为 true，则尝试使用根文件夹下的 mvnw 作为可执行文件；否则尝试使用系统 PATH 中的 mvn。",
-    "configuration.maven.executable.path": "指定mvn可执行文件的绝对路径。当此值为空时，它会根据 maven.executeble.preferMavenWapper 的值尝试使用 mvn 或 mvnw 。请注意，不建议使用相对路径，但如果指定了相对路径，则将从工作区根文件夹（如果存在）中解析绝对路径。",
+    "configuration.maven.executable.path": "指定mvn可执行文件的绝对路径。当此值为空时，它会根据 maven.executable.preferMavenWrapper 的值尝试使用 mvn 或 mvnw 。请注意，不建议使用相对路径，但如果指定了相对路径，则将从工作区根文件夹（如果存在）中解析绝对路径。",
     "configuration.maven.executable.options": "指定所有mvn命令的默认选项。",
     "configuration.maven.terminal.useJavaHome": "如果此值为 true ，并且配置项 java.home 具有值，则在创建新的终端窗口时，将环境变量 JAVA_HOME 设置为 java.home 的值。",
     "configuration.maven.terminal.customEnv": "自定义环境变量。在首次执行 Maven 之前，这些环境变量值将被添加到终端会话中。",
     "configuration.maven.terminal.customEnv.environmentVariable": "要设置的环境变量的名称。",
     "configuration.maven.terminal.customEnv.value": "要设置的环境变量的值。",
-    "configuration.maven.completion.local.enabled": "指定是否要使用本地 Maven 仓库的信息为 POM 文件进行补全。",
     "configuration.maven.view": "指定 Maven 项目的视图方式。"
 }

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import { ElementNode, getCurrentNode, XmlTagName } from "./lexerUtils";
 import { getArtifacts, getVersions } from "./requestUtils";
 
-const artifactSegements: string[] = [
+const artifactSegments: string[] = [
     "\t<groupId>$1</groupId>",
     "\t<artifactId>$2</artifactId>",
     // tslint:disable-next-line:no-invalid-template-strings
@@ -15,12 +15,12 @@ const artifactSegements: string[] = [
 ];
 const dependencySnippet: vscode.SnippetString = new vscode.SnippetString([
     "<dependency>",
-    ...artifactSegements,
+    ...artifactSegments,
     "</dependency>$0"
 ].join("\n"));
 const pluginSnippet: vscode.SnippetString = new vscode.SnippetString([
     "<plugin>",
-    ...artifactSegements,
+    ...artifactSegments,
     "</plugin>$0"
 ].join("\n"));
 
@@ -83,6 +83,7 @@ class RemoteProvider implements vscode.CompletionItemProvider {
                     item.insertText = doc.v;
                     item.sortText = _.padStart(index.toString(), 3, "0");
                     item.range = targetRange;
+                    // TODO: show Updated date in details
                     return item;
                 });
                 return new vscode.CompletionList(versionItems, false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     });
     registerCommand(context, "maven.goal.custom", async (node: MavenProject) => {
         if (node && node.pomPath) {
-            await Utils.excuteCustomGoal(node.pomPath);
+            await Utils.executeCustomGoal(node.pomPath);
         }
     });
     registerCommand(context, "maven.project.openPom", async (node: MavenProject) => {
@@ -123,7 +123,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
         }),
         // configuration change listener
         vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-            // close all terminals with outdated JAVA related Envs
+            // close all terminals with outdated JAVA related environment variables
             if (e.affectsConfiguration("maven.terminal.useJavaHome")
                 || e.affectsConfiguration("maven.terminal.customEnv")
                 || Settings.Terminal.useJavaHome() && e.affectsConfiguration("java.home")
@@ -141,10 +141,4 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     // completion item provider
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider([{ language: "xml", scheme: "file", pattern: "**/pom.xml" }], centralProvider, ".", "-"));
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider([{ language: "xml", scheme: "file", pattern: "**/pom.xml" }], localProvider, "."));
-    if (vscode.workspace.getConfiguration("maven", null).get<boolean>("completion.enabled")) {
-        vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, (progress) => {
-            progress.report({ message: "Updating local Maven repository indices" });
-            return localProvider.initialize();
-        });
-    }
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -159,7 +159,7 @@ export namespace Utils {
         const mvnExecutable: string = await getMaven(workspaceFolder);
         const mvnString: string = wrappedWithQuotes(mvnExecutable);
         // Todo with following line:
-        // 1. pomfile and workspacefolde = undefined, error
+        // 1. pomfile and workspacefolder = undefined, error
         // 2. non-readable
         const commandCwd: string = path.resolve(workspaceFolder.uri.fsPath, mvnExecutable, "..");
 
@@ -317,14 +317,14 @@ export namespace Utils {
         ));
     }
 
-    export async function excuteCustomGoal(pomPath: string): Promise<void> {
+    export async function executeCustomGoal(pomPath: string): Promise<void> {
         if (!pomPath) {
             return;
         }
         const inputGoals: string = await window.showInputBox({ placeHolder: "e.g. clean package -DskipTests", ignoreFocusOut: true });
-        const trimedGoals: string = inputGoals && inputGoals.trim();
-        if (trimedGoals) {
-            Utils.executeInTerminal(trimedGoals, pomPath);
+        const trimmedGoals: string = inputGoals && inputGoals.trim();
+        if (trimmedGoals) {
+            Utils.executeInTerminal(trimmedGoals, pomPath);
         }
     }
 


### PR DESCRIPTION
Original issue: #195 , Continuing work of #197 


### In this PR
- Remove indexing work which cause huge time and CPU cost.
- Searching local Maven repository on completion, with depth of 2. (good performance)
- Typo fixing

### Todo next
- Stop using hard-coded m2_home
- Sort versions in reverse order.



