### PR TITLE
Sort version completion items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
             }
         },
         "@types/lodash": {
-            "version": "4.14.119",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
-            "integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw==",
+            "version": "4.14.120",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.120.tgz",
+            "integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==",
             "dev": true
         },
         "@types/md5": {
@@ -58,6 +58,12 @@
             "version": "8.10.39",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
             "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
+            "dev": true
+        },
+        "@types/semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
             "dev": true
         },
         "@types/xml2js": {
@@ -255,24 +261,21 @@
             "dev": true
         },
         "acorn": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+            "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
             "dev": true
         },
         "acorn-dynamic-import": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-            "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-            "dev": true,
-            "requires": {
-                "acorn": "^5.0.0"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+            "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+            "dev": true
         },
         "ajv": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-            "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+            "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^2.0.1",
@@ -469,7 +472,7 @@
                 },
                 "util": {
                     "version": "0.10.3",
-                    "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
                     "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
                     "dev": true,
                     "requires": {
@@ -540,7 +543,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -716,7 +719,7 @@
         },
         "browserify-aes": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
@@ -753,7 +756,7 @@
         },
         "browserify-rsa": {
             "version": "4.0.1",
-            "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
@@ -787,7 +790,7 @@
         },
         "buffer": {
             "version": "4.9.1",
-            "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
@@ -1226,7 +1229,7 @@
         },
         "create-hash": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
@@ -1239,7 +1242,7 @@
         },
         "create-hmac": {
             "version": "1.1.7",
-            "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
@@ -1445,7 +1448,7 @@
         },
         "diffie-hellman": {
             "version": "5.0.3",
-            "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
@@ -1591,7 +1594,7 @@
         },
         "event-stream": {
             "version": "3.3.4",
-            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
@@ -1605,9 +1608,9 @@
             }
         },
         "events": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
             "dev": true
         },
         "evp_bytestokey": {
@@ -1967,9 +1970,9 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+            "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -1995,7 +1998,7 @@
                     "optional": true
                 },
                 "are-we-there-yet": {
-                    "version": "1.1.4",
+                    "version": "1.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2019,7 +2022,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2055,7 +2058,7 @@
                     }
                 },
                 "deep-extend": {
-                    "version": "0.5.1",
+                    "version": "0.6.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2104,7 +2107,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2124,12 +2127,12 @@
                     "optional": true
                 },
                 "iconv-lite": {
-                    "version": "0.4.21",
+                    "version": "0.4.24",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ignore-walk": {
@@ -2190,16 +2193,16 @@
                     "dev": true
                 },
                 "minipass": {
-                    "version": "2.2.4",
+                    "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
-                    "version": "1.1.0",
+                    "version": "1.2.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2222,7 +2225,7 @@
                     "optional": true
                 },
                 "needle": {
-                    "version": "2.2.0",
+                    "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2233,18 +2236,18 @@
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.10.0",
+                    "version": "0.10.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
                         "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
+                        "needle": "^2.2.1",
                         "nopt": "^4.0.1",
                         "npm-packlist": "^1.1.6",
                         "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
+                        "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
                         "tar": "^4"
@@ -2261,13 +2264,13 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.3",
+                    "version": "1.0.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.1.10",
+                    "version": "1.2.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2342,12 +2345,12 @@
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.7",
+                    "version": "1.2.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
+                        "deep-extend": "^0.6.0",
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
@@ -2377,16 +2380,16 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.1",
+                    "version": "5.1.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -2403,7 +2406,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.6.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2454,17 +2457,17 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "4.4.1",
+                    "version": "4.4.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
+                        "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
                         "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.2"
                     }
                 },
@@ -2475,12 +2478,12 @@
                     "optional": true
                 },
                 "wide-align": {
-                    "version": "1.1.2",
+                    "version": "1.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "^1.0.2 || 2"
                     }
                 },
                 "wrappy": {
@@ -2489,7 +2492,7 @@
                     "dev": true
                 },
                 "yallist": {
-                    "version": "3.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true
                 }
@@ -3063,9 +3066,9 @@
             "dev": true
         },
         "is": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
             "dev": true
         },
         "is-absolute": {
@@ -3290,9 +3293,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -3323,14 +3326,11 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "json-stable-stringify": {
+        "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true,
-            "requires": {
-                "jsonify": "~0.0.0"
-            }
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -3351,12 +3351,6 @@
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
-        },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
         },
         "jsprim": {
             "version": "1.4.1",
@@ -3410,9 +3404,9 @@
             "dev": true
         },
         "loader-runner": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-            "integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+            "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
             "dev": true
         },
         "loader-utils": {
@@ -3481,7 +3475,7 @@
         },
         "map-stream": {
             "version": "0.1.0",
-            "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
@@ -3868,9 +3862,9 @@
             "dev": true
         },
         "node-libs-browser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-            "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+            "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
             "dev": true,
             "requires": {
                 "assert": "^1.1.1",
@@ -3880,7 +3874,7 @@
                 "constants-browserify": "^1.0.0",
                 "crypto-browserify": "^3.11.0",
                 "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
+                "events": "^3.0.0",
                 "https-browserify": "^1.0.0",
                 "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
@@ -3894,7 +3888,7 @@
                 "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
                 "url": "^0.11.0",
-                "util": "^0.10.3",
+                "util": "^0.11.0",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -4109,9 +4103,9 @@
             "dev": true
         },
         "pako": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
-            "integrity": "sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+            "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
             "dev": true
         },
         "parallel-transform": {
@@ -4126,16 +4120,17 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.1",
-            "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-            "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+            "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
             "dev": true,
             "requires": {
                 "asn1.js": "^4.0.0",
                 "browserify-aes": "^1.0.0",
                 "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
             }
         },
         "parse-passwd": {
@@ -4276,9 +4271,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
         "public-encrypt": {
@@ -4518,9 +4513,9 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
-            "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
@@ -4571,12 +4566,12 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "^7.1.3"
             }
         },
         "ripemd160": {
@@ -4634,14 +4629,14 @@
             }
         },
         "semver": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-            "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "serialize-javascript": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.0.tgz",
-            "integrity": "sha512-AQxrNqu4EXWt03dJdgKXI+Au9+pvEuM5+Nk5g6+TmuxMCkEL03VhZ31HM+VKeaaZbFpDHaoSruiHq4PW9AIrOQ==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+            "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
             "dev": true
         },
         "set-blocking": {
@@ -4679,7 +4674,7 @@
         },
         "sha.js": {
             "version": "2.4.11",
-            "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
@@ -4858,9 +4853,9 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+            "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -4874,7 +4869,7 @@
         },
         "split": {
             "version": "0.3.3",
-            "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
@@ -4915,9 +4910,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+            "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
             "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
@@ -4966,9 +4961,9 @@
             }
         },
         "stream-browserify": {
-            "version": "2.0.1",
-            "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
             "dev": true,
             "requires": {
                 "inherits": "~2.0.1",
@@ -4977,7 +4972,7 @@
         },
         "stream-combiner": {
             "version": "0.0.4",
-            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
@@ -5103,9 +5098,9 @@
             }
         },
         "terser": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-3.13.1.tgz",
-            "integrity": "sha512-ogyZye4DFqOtMzT92Y3Nxxw8OvXmL39HOALro4fc+EUYFFF9G/kk0znkvwMz6PPYgBtdKAodh3FPR70eugdaQA==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
+            "integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
             "dev": true,
             "requires": {
                 "commander": "~2.17.1",
@@ -5122,9 +5117,9 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.0.tgz",
-            "integrity": "sha512-QW7RACLS89RalHtLDb0s8+Iqcs/IAEw1rnVrV+mS7Gx1kgPG8o1g33JhAGDgc/CQ84hLsTW5WrAMdVysh692yg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
+            "integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
             "dev": true,
             "requires": {
                 "cacache": "^11.0.2",
@@ -5167,9 +5162,9 @@
             }
         },
         "through2-filter": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
                 "through2": "~2.0.0",
@@ -5664,9 +5659,9 @@
             "dev": true
         },
         "tslint": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.0.tgz",
-            "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+            "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
             "dev": true,
             "requires": {
                 "babel-code-frame": "^6.22.0",
@@ -5813,13 +5808,13 @@
             }
         },
         "unique-stream": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "through2-filter": "^3.0.0"
             }
         },
         "universalify": {
@@ -5922,9 +5917,9 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "util": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+            "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
             "dev": true,
             "requires": {
                 "inherits": "2.0.3"
@@ -6090,9 +6085,9 @@
             }
         },
         "vscode": {
-            "version": "1.1.26",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.26.tgz",
-            "integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
+            "version": "1.1.27",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.27.tgz",
+            "integrity": "sha512-czmqqiuvQLqkZLt1zJgQWgFHlGBkvQzR4xsXfA/U1hZaaWlIB8+kg4gMbl7IW0TRvkGG/WEuAEKgrrVI237ymA==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2",
@@ -6141,17 +6136,17 @@
             }
         },
         "webpack": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.28.2.tgz",
-            "integrity": "sha512-PK3uVg3/NuNVOjPfYleFI6JF7khO7c2kIlksH7mivQm+QDcwiqV1x6+q89dDeOioh5FNxJHr3LKbDu3oSAhl9g==",
+            "version": "4.29.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",
+            "integrity": "sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.7.11",
                 "@webassemblyjs/helper-module-context": "1.7.11",
                 "@webassemblyjs/wasm-edit": "1.7.11",
                 "@webassemblyjs/wasm-parser": "1.7.11",
-                "acorn": "^5.6.2",
-                "acorn-dynamic-import": "^3.0.0",
+                "acorn": "^6.0.5",
+                "acorn-dynamic-import": "^4.0.0",
                 "ajv": "^6.1.0",
                 "ajv-keywords": "^3.1.0",
                 "chrome-trace-event": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -423,17 +423,18 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^4.0.8",
-    "@types/lodash": "^4.14.119",
+    "@types/lodash": "^4.14.120",
     "@types/md5": "^2.1.33",
     "@types/minimatch": "^3.0.3",
     "@types/node": "^8.10.39",
+    "@types/semver": "^5.5.0",
     "@types/xml2js": "^0.4.3",
     "ts-loader": "^4.4.2",
-    "tslint": "^5.12.0",
+    "tslint": "^5.12.1",
     "tslint-microsoft-contrib": "^5.0.1",
     "typescript": "^2.9.2",
-    "vscode": "^1.1.26",
-    "webpack": "^4.28.2",
+    "vscode": "^1.1.27",
+    "webpack": "^4.29.0",
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
@@ -442,6 +443,7 @@
     "lodash": "^4.17.11",
     "md5": "^2.2.1",
     "minimatch": "^3.0.4",
+    "semver": "^5.6.0",
     "vscode-extension-telemetry-wrapper": "0.3.8",
     "xml-zero-lexer": "^2.0.5",
     "xml2js": "^0.4.19"

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode";
 
 import { ElementNode, getCurrentNode, XmlTagName } from "./lexerUtils";
 import { getArtifacts, getVersions } from "./requestUtils";
+import { getSortText } from "./versionUtils";
 
 const artifactSegments: string[] = [
     "\t<groupId>$1</groupId>",
@@ -63,7 +64,7 @@ class RemoteProvider implements vscode.CompletionItemProvider {
                     const item: vscode.CompletionItem = new vscode.CompletionItem(doc.a, vscode.CompletionItemKind.Field);
                     item.insertText = doc.a;
                     item.range = targetRange;
-                    item.detail = doc.g;
+                    item.detail = `groupId: ${doc.g}`;
                     return item;
                 });
                 return new vscode.CompletionList(artifactIdItems, false);
@@ -78,12 +79,12 @@ class RemoteProvider implements vscode.CompletionItemProvider {
 
                 const body: any = await getVersions(groupIdNode.text, artifactIdNode.text);
                 const docs: any[] = _.get(body, "response.docs", []);
-                const versionItems: vscode.CompletionItem[] = docs.map((doc, index) => {
+                const versionItems: vscode.CompletionItem[] = docs.map((doc) => {
                     const item: vscode.CompletionItem = new vscode.CompletionItem(doc.v, vscode.CompletionItemKind.Constant);
                     item.insertText = doc.v;
-                    item.sortText = _.padStart(index.toString(), 3, "0");
                     item.range = targetRange;
-                    // TODO: show Updated date in details
+                    item.detail = `Updated: ${new Date(doc.timestamp).toLocaleDateString()}`;
+                    item.sortText = getSortText(doc.v);
                     return item;
                 });
                 return new vscode.CompletionList(versionItems, false);

--- a/src/completion/localProvider.ts
+++ b/src/completion/localProvider.ts
@@ -7,6 +7,7 @@ import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { ElementNode, getCurrentNode } from "./lexerUtils";
+import { getSortText } from "./versionUtils";
 
 class LocalProvider implements vscode.CompletionItemProvider {
     public localRepository: string = path.join(os.homedir(), ".m2", "repository");  // TODO: use effective m2 home.
@@ -90,7 +91,7 @@ class LocalProvider implements vscode.CompletionItemProvider {
             item.insertText = v;
             item.range = targetRange;
             item.detail = "local";
-            // TODO: use sortText to list latest version at top.
+            item.sortText = getSortText(v);
             return item;
         });
         return new vscode.CompletionList(versionItems, false);

--- a/src/completion/versionUtils.ts
+++ b/src/completion/versionUtils.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as _ from "lodash";
+import {parse, SemVer} from "semver";
+
+const VERSION_VALUE_MAX: number = 999;
+const VERSION_VALUE_DIGITS: number = 3;
+// tslint:disable-next-line:export-name
+export function getSortText(version: string): string {
+    const ver: SemVer = parse(version);
+    const versionValues: number[] = ver ? [ver.major, ver.minor, ver.patch] : [0, 0, 0];
+    return versionValues.map(v => _.padStart((VERSION_VALUE_MAX - v).toString(), VERSION_VALUE_DIGITS, "0")).join();
+}


### PR DESCRIPTION
Original issue: #195 

### In this PR
Versions are sorted with the latest at the top, in the following way via the util `getSortText(ver)`:
- Format of a semantic version is `major`.`minor`.`patch`-`identifier`
- Given a max value of 999 (in most cases) `sortText` is a string joined by `999-major`, `999-minor`, `999-patch`, with leading zeros.
- A non-semantic version is regarded as "0.0.0" when being sorted.

#### E.g.
`9.0.0` will be sorted by text "990999999"
`1.2.3-SNAPSHOT` will be sorted by text "998997996"
`4.5` will be sorted by text "999999999"

