### PR TITLE
Fix scope of the config maven.view

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
               "hierarchical"
             ],
             "default": "flat",
-            "scope": "resource",
+            "scope": "window",
             "description": "%configuration.maven.view%"
           }
         }


### PR DESCRIPTION
The scope should be "window", should be shared among workspaceFolders.

#### Reason:
When a user hits the button from explorer to switch the view, it's unable to identify the resource. 