### PR TITLE
Robustness: safer request url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-maven",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -42,7 +42,7 @@ class RemoteProvider implements vscode.CompletionItemProvider {
                 const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
                 const artifactIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.ArtifactId);
                 const query: string = _.isEmpty(artifactIdNode && artifactIdNode.text) ? currentNode.text : `${currentNode.text} ${artifactIdNode.text}`;
-                const body: any = await getArtifacts(query);
+                const body: any = await getArtifacts(query.trim());
                 const docs: any[] = _.get(body, "response.docs", []);
                 const groupIds: string[] = Array.from(new Set(docs.map(doc => doc.g)).values());
                 const groupIdItems: vscode.CompletionItem[] = groupIds.map(gid => {
@@ -58,7 +58,7 @@ class RemoteProvider implements vscode.CompletionItemProvider {
                 const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
                 const groupIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.GroupId);
                 const query: string = _.isEmpty(groupIdNode && groupIdNode.text) ? currentNode.text : `${currentNode.text} ${groupIdNode.text}`;
-                const body: any = await getArtifacts(query);
+                const body: any = await getArtifacts(query.trim());
                 const docs: any[] = _.get(body, "response.docs", []);
                 const artifactIdItems: vscode.CompletionItem[] = docs.map(doc => {
                     const item: vscode.CompletionItem = new vscode.CompletionItem(doc.a, vscode.CompletionItemKind.Field);

--- a/src/completion/requestUtils.ts
+++ b/src/completion/requestUtils.ts
@@ -13,7 +13,7 @@ export async function getArtifacts(keyword: string): Promise<{}> {
         rows: 20,
         wt: "json"
     };
-    const raw: string = await httpGet(`${URL_BASIC_SEARCH}?${toQueryString(params)}`);
+    const raw: string = await httpsGet(`${URL_BASIC_SEARCH}?${toQueryString(params)}`);
     return JSON.parse(raw);
 }
 
@@ -24,14 +24,14 @@ export async function getVersions(gid: string, aid: string): Promise<{}> {
         rows: 50,
         wt: "json"
     };
-    const raw: string = await httpGet(`${URL_BASIC_SEARCH}?${toQueryString(params)}`);
+    const raw: string = await httpsGet(`${URL_BASIC_SEARCH}?${toQueryString(params)}`);
     return JSON.parse(raw);
 }
 
-function httpGet(options: string | url.URL | https.RequestOptions): Promise<string> {
+function httpsGet(urlString: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         let result: string = "";
-        https.get(options, (res: http.IncomingMessage) => {
+        https.get(url.parse(urlString), (res: http.IncomingMessage) => {
             res.on("data", chunk => {
                 result = result.concat(chunk.toString());
             });


### PR DESCRIPTION
For #195 
In VSCode Insider, http.proxy_support = override by default, and the request breaks in some cases. 