### PR TITLE
Remove duplicated items in completion list

### DIFF
--- a/src/completion/IArtifactProvider.ts
+++ b/src/completion/IArtifactProvider.ts
@@ -3,7 +3,7 @@
 
 import { CompletionItem } from "vscode";
 
-export interface IArtifactProvider {
+export interface IMavenCompletionItemProvider {
     getGroupIdCandidates(groupIdHint?: string, artifactIdHint?: string): Promise<CompletionItem[]>;
     getArtifactIdCandidates(groupIdHint?: string, artifactIdHint?: string): Promise<CompletionItem[]>;
     getVersionCandidates(groupIdHint?: string, artifactIdHint?: string, versionHint?: string): Promise<CompletionItem[]>;

--- a/src/completion/IArtifactProvider.ts
+++ b/src/completion/IArtifactProvider.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { CompletionItem } from "vscode";
+
+export interface IArtifactProvider {
+    getGroupIdCandidates(groupIdHint?: string, artifactIdHint?: string): Promise<CompletionItem[]>;
+    getArtifactIdCandidates(groupIdHint?: string, artifactIdHint?: string): Promise<CompletionItem[]>;
+    getVersionCandidates(groupIdHint?: string, artifactIdHint?: string, versionHint?: string): Promise<CompletionItem[]>;
+}

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -3,113 +3,51 @@
 
 import * as _ from "lodash";
 import * as vscode from "vscode";
-
-import { ElementNode, getCurrentNode, XmlTagName } from "./lexerUtils";
+import { IArtifactProvider } from "./IArtifactProvider";
 import { getArtifacts, getVersions } from "./requestUtils";
 import { getSortText } from "./versionUtils";
 
-const artifactSegments: string[] = [
-    "\t<groupId>$1</groupId>",
-    "\t<artifactId>$2</artifactId>",
-    // tslint:disable-next-line:no-invalid-template-strings
-    "\t<version>${3:(0.0.0,)}</version>"
-];
-const dependencySnippet: vscode.SnippetString = new vscode.SnippetString([
-    "<dependency>",
-    ...artifactSegments,
-    "</dependency>$0"
-].join("\n"));
-const pluginSnippet: vscode.SnippetString = new vscode.SnippetString([
-    "<plugin>",
-    ...artifactSegments,
-    "</plugin>$0"
-].join("\n"));
-
-class RemoteProvider implements vscode.CompletionItemProvider {
-    public async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[] | vscode.CompletionList> {
-
-        const currentNode: ElementNode = getCurrentNode(document, position);
-        if (!currentNode) {
-            return null;
-        }
-
-        const targetRange: vscode.Range = new vscode.Range(
-            currentNode.offset ? document.positionAt(currentNode.offset) : position,
-            position
-        );
-        switch (currentNode.tag) {
-            case XmlTagName.GroupId: {
-                const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
-                const artifactIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.ArtifactId);
-                const query: string = _.isEmpty(artifactIdNode && artifactIdNode.text) ? currentNode.text : `${currentNode.text} ${artifactIdNode.text}`;
-                const body: any = await getArtifacts(query.trim());
-                const docs: any[] = _.get(body, "response.docs", []);
-                const groupIds: string[] = Array.from(new Set(docs.map(doc => doc.g)).values());
-                const groupIdItems: vscode.CompletionItem[] = groupIds.map(gid => {
-                    const item: vscode.CompletionItem = new vscode.CompletionItem(gid, vscode.CompletionItemKind.Module);
-                    item.insertText = gid;
-                    item.range = targetRange;
-                    item.detail = "central";
-                    return item;
-                });
-                return new vscode.CompletionList(groupIdItems, false);
-            }
-            case XmlTagName.ArtifactId: {
-                const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
-                const groupIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.GroupId);
-                const query: string = _.isEmpty(groupIdNode && groupIdNode.text) ? currentNode.text : `${currentNode.text} ${groupIdNode.text}`;
-                const body: any = await getArtifacts(query.trim());
-                const docs: any[] = _.get(body, "response.docs", []);
-                const artifactIdItems: vscode.CompletionItem[] = docs.map(doc => {
-                    const item: vscode.CompletionItem = new vscode.CompletionItem(doc.a, vscode.CompletionItemKind.Field);
-                    item.insertText = doc.a;
-                    item.range = targetRange;
-                    item.detail = `groupId: ${doc.g}`;
-                    return item;
-                });
-                return new vscode.CompletionList(artifactIdItems, false);
-            }
-            case XmlTagName.Version: {
-                const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
-                const groupIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.GroupId);
-                const artifactIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.ArtifactId);
-                if (!groupIdNode && !artifactIdNode) {
-                    return null;
-                }
-
-                const body: any = await getVersions(groupIdNode.text, artifactIdNode.text);
-                const docs: any[] = _.get(body, "response.docs", []);
-                const versionItems: vscode.CompletionItem[] = docs.map((doc) => {
-                    const item: vscode.CompletionItem = new vscode.CompletionItem(doc.v, vscode.CompletionItemKind.Constant);
-                    item.insertText = doc.v;
-                    item.range = targetRange;
-                    item.detail = `Updated: ${new Date(doc.timestamp).toLocaleDateString()}`;
-                    item.sortText = getSortText(doc.v);
-                    return item;
-                });
-                return new vscode.CompletionList(versionItems, false);
-            }
-            case XmlTagName.Dependencies: {
-                const snippetItem: vscode.CompletionItem = new vscode.CompletionItem("dependency", vscode.CompletionItemKind.Snippet);
-                snippetItem.insertText = dependencySnippet;
-                snippetItem.detail = "Maven Snippet";
-                return new vscode.CompletionList([snippetItem], false);
-            }
-            case XmlTagName.Plugins: {
-                const snippetItem: vscode.CompletionItem = new vscode.CompletionItem("plugin", vscode.CompletionItemKind.Snippet);
-                snippetItem.insertText = pluginSnippet;
-                snippetItem.detail = "Maven Snippet";
-                return new vscode.CompletionList([snippetItem], false);
-            }
-            default:
-                return null;
-        }
+class CentralArtifactProvider implements IArtifactProvider {
+    public async getGroupIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {
+        const query: string = `${groupIdHint} ${artifactIdHint}`.trim();
+        const body: any = await getArtifacts(query);
+        const docs: any[] = _.get(body, "response.docs", []);
+        const groupIds: string[] = Array.from(new Set(docs.map(doc => doc.g)).values());
+        return groupIds.map(gid => {
+            const item: vscode.CompletionItem = new vscode.CompletionItem(gid, vscode.CompletionItemKind.Module);
+            item.insertText = gid;
+            item.detail = "central";
+            return item;
+        });
     }
 
-    public resolveCompletionItem?(item: vscode.CompletionItem, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
-        return item;
+    public async getArtifactIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {
+        const query: string = `${groupIdHint} ${artifactIdHint}`.trim();
+        const body: any = await getArtifacts(query.trim());
+        const docs: any[] = _.get(body, "response.docs", []);
+        return docs.map(doc => {
+            const item: vscode.CompletionItem = new vscode.CompletionItem(doc.a, vscode.CompletionItemKind.Field);
+            item.insertText = doc.a;
+            item.detail = `GroupId: ${doc.g}`;
+            return item;
+        });
     }
 
+    public async getVersionCandidates(groupId: string, artifactId: string): Promise<vscode.CompletionItem[]> {
+        if (!groupId && !artifactId) {
+            return [];
+        }
+
+        const body: any = await getVersions(groupId, artifactId);
+        const docs: any[] = _.get(body, "response.docs", []);
+        return docs.map((doc) => {
+            const item: vscode.CompletionItem = new vscode.CompletionItem(doc.v, vscode.CompletionItemKind.Constant);
+            item.insertText = doc.v;
+            item.detail = `Updated: ${new Date(doc.timestamp).toLocaleDateString()}`;
+            item.sortText = getSortText(doc.v);
+            return item;
+        });
+    }
 }
 
-export const centralProvider: RemoteProvider = new RemoteProvider();
+export const centralProvider: IArtifactProvider = new CentralArtifactProvider();

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -3,11 +3,11 @@
 
 import * as _ from "lodash";
 import * as vscode from "vscode";
-import { IArtifactProvider } from "./IArtifactProvider";
+import { IMavenCompletionItemProvider } from "./IArtifactProvider";
 import { getArtifacts, getVersions } from "./requestUtils";
 import { getSortText } from "./versionUtils";
 
-class CentralArtifactProvider implements IArtifactProvider {
+class CentralProvider implements IMavenCompletionItemProvider {
     public async getGroupIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {
         const query: string = `${groupIdHint} ${artifactIdHint}`.trim();
         const body: any = await getArtifacts(query);
@@ -50,4 +50,4 @@ class CentralArtifactProvider implements IArtifactProvider {
     }
 }
 
-export const centralProvider: IArtifactProvider = new CentralArtifactProvider();
+export const centralProvider: IMavenCompletionItemProvider = new CentralProvider();

--- a/src/completion/completionProvider.ts
+++ b/src/completion/completionProvider.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as _ from "lodash";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import { centralProvider } from "./centralProvider";
+import { ElementNode, getCurrentNode, XmlTagName } from "./lexerUtils";
+import { localProvider } from "./localProvider";
+
+const artifactSegments: string[] = [
+    "\t<groupId>$1</groupId>",
+    "\t<artifactId>$2</artifactId>",
+    // tslint:disable-next-line:no-invalid-template-strings
+    "\t<version>${3:(0.0.0,)}</version>"
+];
+const dependencySnippet: vscode.SnippetString = new vscode.SnippetString([
+    "<dependency>",
+    ...artifactSegments,
+    "</dependency>$0"
+].join("\n"));
+const pluginSnippet: vscode.SnippetString = new vscode.SnippetString([
+    "<plugin>",
+    ...artifactSegments,
+    "</plugin>$0"
+].join("\n"));
+
+class CompletionProvider implements vscode.CompletionItemProvider {
+    public localRepository: string = path.join(os.homedir(), ".m2", "repository");
+
+    public async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[] | vscode.CompletionList> {
+
+        const currentNode: ElementNode = getCurrentNode(document, position);
+        if (!currentNode) {
+            return null;
+        }
+
+        const targetRange: vscode.Range = new vscode.Range(
+            currentNode.offset ? document.positionAt(currentNode.offset) : position,
+            position
+        );
+        switch (currentNode.tag) {
+            case XmlTagName.GroupId: {
+                const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
+                const artifactIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.ArtifactId);
+                const groupIdHint: string = currentNode.text || "";
+                const artifactIdHint: string = artifactIdNode && artifactIdNode.text || "";
+
+                const centralItems: vscode.CompletionItem[] = await centralProvider.getGroupIdCandidates(groupIdHint, artifactIdHint);
+                const localItems: vscode.CompletionItem[] = await localProvider.getGroupIdCandidates(groupIdHint, artifactIdHint);
+                const mergedItems: vscode.CompletionItem[] = this.deDuplicate(centralItems, localItems);
+                mergedItems.forEach(item => item.range = targetRange);
+                return new vscode.CompletionList(mergedItems, false);
+            }
+            case XmlTagName.ArtifactId: {
+                const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
+                const groupIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.GroupId);
+                const groupIdHint: string = groupIdNode && groupIdNode.text || "";
+                const artifactIdHint: string = currentNode.text || "";
+
+                const centralItems: vscode.CompletionItem[] = await centralProvider.getArtifactIdCandidates(groupIdHint, artifactIdHint);
+                // To add additionalTextEdit to update group id.
+                const localItems: vscode.CompletionItem[] = await localProvider.getArtifactIdCandidates(groupIdHint, artifactIdHint);
+                return new vscode.CompletionList([].concat(centralItems, localItems), false);
+            }
+            case XmlTagName.Version: {
+                const siblingNodes: ElementNode[] = _.get(currentNode, "parent.children", []);
+                const groupIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.GroupId);
+                const artifactIdNode: ElementNode = siblingNodes.find(elem => elem.tag === XmlTagName.ArtifactId);
+                const groupIdHint: string = groupIdNode && groupIdNode.text || "";
+                const artifactIdHint: string = artifactIdNode && artifactIdNode.text || "";
+
+                const centralItems: vscode.CompletionItem[] = await centralProvider.getVersionCandidates(groupIdHint, artifactIdHint);
+                const localItems: vscode.CompletionItem[] = await localProvider.getVersionCandidates(groupIdHint, artifactIdHint);
+                const mergedItems: vscode.CompletionItem[] = this.deDuplicate(centralItems, localItems);
+                mergedItems.forEach(item => item.range = targetRange);
+                return new vscode.CompletionList(mergedItems, false);
+            }
+            case XmlTagName.Dependencies: {
+                const snippetItem: vscode.CompletionItem = new vscode.CompletionItem("dependency", vscode.CompletionItemKind.Snippet);
+                snippetItem.insertText = dependencySnippet;
+                snippetItem.detail = "Maven Snippet";
+                return new vscode.CompletionList([snippetItem], false);
+            }
+            case XmlTagName.Plugins: {
+                const snippetItem: vscode.CompletionItem = new vscode.CompletionItem("plugin", vscode.CompletionItemKind.Snippet);
+                snippetItem.insertText = pluginSnippet;
+                snippetItem.detail = "Maven Snippet";
+                return new vscode.CompletionList([snippetItem], false);
+            }
+            default:
+                return null;
+        }
+    }
+
+    private deDuplicate(primary: vscode.CompletionItem[], secondary: vscode.CompletionItem[]): vscode.CompletionItem[] {
+        return _.unionBy(primary, secondary, (item) => item.insertText);
+    }
+}
+
+export const completionProvider: CompletionProvider = new CompletionProvider();

--- a/src/completion/localProvider.ts
+++ b/src/completion/localProvider.ts
@@ -6,10 +6,10 @@ import * as _ from "lodash";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
-import { IArtifactProvider } from "./IArtifactProvider";
+import { IMavenCompletionItemProvider } from "./IArtifactProvider";
 import { getSortText } from "./versionUtils";
 
-class LocalProvider implements IArtifactProvider {
+class LocalProvider implements IMavenCompletionItemProvider {
     public localRepository: string = path.join(os.homedir(), ".m2", "repository");
 
     public async getGroupIdCandidates(groupIdHint: string): Promise<vscode.CompletionItem[]> {
@@ -87,4 +87,4 @@ class LocalProvider implements IArtifactProvider {
 
 }
 
-export const localProvider: IArtifactProvider = new LocalProvider();
+export const localProvider: IMavenCompletionItemProvider = new LocalProvider();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,7 @@ import * as vscode from "vscode";
 import { Progress, Uri } from "vscode";
 import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import { ArchetypeModule } from "./archetype/ArchetypeModule";
-import { centralProvider } from "./completion/centralProvider";
-import { localProvider } from "./completion/localProvider";
+import { completionProvider } from "./completion/completionProvider";
 import { OperationCanceledError } from "./Errors";
 import { mavenExplorerProvider } from "./explorer/mavenExplorerProvider";
 import { ITreeItem } from "./explorer/model/ITreeItem";
@@ -139,6 +138,5 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
         })
     );
     // completion item provider
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider([{ language: "xml", scheme: "file", pattern: "**/pom.xml" }], centralProvider, ".", "-"));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider([{ language: "xml", scheme: "file", pattern: "**/pom.xml" }], localProvider, "."));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider([{ language: "xml", scheme: "file", pattern: "**/pom.xml" }], completionProvider, ".", "-"));
 }


### PR DESCRIPTION
Previously it uses two completion providers, with duplicated results sometimes.

Now combine them into one, removing the dup items.