### PR TITLE
Update groupId together if possible when completing artifactId

### DIFF
--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -29,6 +29,7 @@ class CentralProvider implements IMavenCompletionItemProvider {
             const item: vscode.CompletionItem = new vscode.CompletionItem(doc.a, vscode.CompletionItemKind.Field);
             item.insertText = doc.a;
             item.detail = `GroupId: ${doc.g}`;
+            (<any>item).data = { groupId: doc.g };
             return item;
         });
     }

--- a/src/completion/lexerUtils.ts
+++ b/src/completion/lexerUtils.ts
@@ -72,7 +72,7 @@ function getElementHierarchy(text: string, tokens: number[][], cursorOffset: num
         switch (token[0]) {
             case NodeTypes.XML_DECLARATION:
             case NodeTypes.ELEMENT_NODE: {
-                // const [_type, start, end] = token;
+                // [_type, start, end] = token;
                 const [start, end] = token.slice(1, 3);
                 const newElement: ElementNode = new ElementNode(currentNode, text.substring(start, end));
                 if (currentNode) {
@@ -83,10 +83,9 @@ function getElementHierarchy(text: string, tokens: number[][], cursorOffset: num
                 elementNodes.push(newElement);
                 newElement.contentStart = pointer;
                 break;
-
             }
             case NodeTypes.ATTRIBUTE_NODE: {
-                // const [_type, _keyStart, _keyEnd, _valueStart, valueEnd] = token;
+                // [_type, _keyStart, _keyEnd, _valueStart, valueEnd] = token;
                 const valueEnd: number = token[4];
                 // Attributes not handled yet.
                 pointer = valueEnd + 1; // pass ">" mark.
@@ -94,7 +93,7 @@ function getElementHierarchy(text: string, tokens: number[][], cursorOffset: num
                 break;
             }
             case NodeTypes.TEXT_NODE: {
-                // const [_type, start, end] = token;
+                // [_type, start, end] = token;
                 const [start, end] = token.slice(1, 3);
                 if (currentNode) {
                     currentNode.text = text.substring(start, end);
@@ -118,6 +117,7 @@ function getElementHierarchy(text: string, tokens: number[][], cursorOffset: num
     return cursorNode || elementNodes[elementNodes.length - 1];
 }
 
+// Definition from xml-zero-lexer
 enum NodeTypes {
     XML_DECLARATION = 0, // unofficial
     // Most XML parsers ignore this but because I'm parsing it I may as well include it.

--- a/src/completion/lexerUtils.ts
+++ b/src/completion/lexerUtils.ts
@@ -16,7 +16,8 @@ export class ElementNode {
     public parent: ElementNode;
     public tag: string;
     public text?: string;
-    public offset?: number; // global offset of the text part.
+    public contentStart?: number;
+    public contentEnd?: number;
     public children?: ElementNode[];
 
     constructor(parent: ElementNode, tag: string) {
@@ -60,41 +61,101 @@ export function getCurrentNode(document: vscode.TextDocument, position: vscode.P
 
 function getElementHierarchy(text: string, tokens: number[][], cursorOffset: number): ElementNode {
     const n: number = tokens.length;
+    const elementNodes: ElementNode[] = [];
     let cursorNode: ElementNode = null;
-    let iter: ElementNode = null;
-    let iterPrev: ElementNode = null;
+    let pointer: number = 0;
     let i: number = 0;
+
     while (i < n) {
         const token: number[] = tokens[i];
+        const currentNode: ElementNode = elementNodes[elementNodes.length - 1];
         switch (token[0]) {
-            case 1: // ELEMENT_NODE
-                const newElement: ElementNode = new ElementNode(iter, text.substring(token[1], token[2]));
-                if (iter) {
-                    iter.addChild(newElement);
+            case NodeTypes.XML_DECLARATION:
+            case NodeTypes.ELEMENT_NODE: {
+                // const [_type, start, end] = token;
+                const [start, end] = token.slice(1, 3);
+                const newElement: ElementNode = new ElementNode(currentNode, text.substring(start, end));
+                if (currentNode) {
+                    currentNode.addChild(newElement);
                 }
-                iter = newElement;
+
+                pointer = end + 1; // pass ">" mark.
+                elementNodes.push(newElement);
+                newElement.contentStart = pointer;
                 break;
-            case 3: // TEXT_NODE
-                if (iter) {
-                    iter.text = text.substring(token[1], token[2]);
-                    iter.offset = token[1];
+
+            }
+            case NodeTypes.ATTRIBUTE_NODE: {
+                // const [_type, _keyStart, _keyEnd, _valueStart, valueEnd] = token;
+                const valueEnd: number = token[4];
+                // Attributes not handled yet.
+                pointer = valueEnd + 1; // pass ">" mark.
+                currentNode.contentStart = pointer;
+                break;
+            }
+            case NodeTypes.TEXT_NODE: {
+                // const [_type, start, end] = token;
+                const [start, end] = token.slice(1, 3);
+                if (currentNode) {
+                    currentNode.text = text.substring(start, end);
                 }
+                pointer = end;
                 break;
-            case 13: // CLOSE_ELEMENT
-                iterPrev = iter;
-                iter = iter.parent;
+            }
+            case NodeTypes.CLOSE_ELEMENT: {
+                currentNode.contentEnd = pointer;
+                elementNodes.pop();
                 break;
+            }
             default:
                 break;
         }
-        if (!cursorNode) {
-            if (cursorOffset <= token[1]) {
-                cursorNode = iterPrev;
-            } else if (cursorOffset <= token[2]) {
-                cursorNode = iter;
-            }
+        if (!cursorNode && currentNode && currentNode.contentStart <= cursorOffset && currentNode.contentEnd && cursorOffset <= currentNode.contentEnd) {
+            cursorNode = currentNode;
         }
         i += 1;
     }
-    return cursorNode;
+    return cursorNode || elementNodes[elementNodes.length - 1];
+}
+
+enum NodeTypes {
+    XML_DECLARATION = 0, // unofficial
+    // Most XML parsers ignore this but because I'm parsing it I may as well include it.
+    // At least it lets you know if there were multiple declarations.
+    //
+    // Also inserting it here makes Object.keys(NodeTypes) array indexes line up with values!
+    // E.g. Object.keys(NodeTypes)[0] === NodeTypes.XML_DECLARATION
+    // (Strictly speaking map keys are unordered but in practice they are, and we don't rely on it)
+    ELEMENT_NODE = 1,
+    ATTRIBUTE_NODE = 2,
+    TEXT_NODE = 3, // Note that these can include entities which should be resolved before display
+    CDATA_SECTION_NODE = 4,
+    ENTITY_REFERENCE_NODE = 5, // Not used
+    //
+    // After a lot of thought I've decided that entities shouldn't be resolved in the Lexer,
+    //
+    // Instead entities are just ignored and are stored as-is as part of the node because =
+    // (1) We only support entities that resolve to characters, we don't support crufty
+    //     complicated entities that insert elements, so there's no actual structural need to
+    //     do it.
+    // (2) It simplifies the code and data structures, and it shrinks data structure memory usage.
+    //     E.g. Text doesn't need to switch between TEXT_NODE and ENTITY_REFERENCE_NODE.
+    // (3) They can be resolved later using a utility function. E.g. have a .textContent() on
+    //     nodes that resolves it. This approach would probably result in less memory use.
+    // (4) It's slightly against style of zero-copy because we'd need to make new strings
+    //     to resolve the entities. Not a difficult job but again it's unnecessary memory use.
+    //
+    //  So I've decided that's not the job of this lexer.
+    //
+    ENTITY_NODE = 6, // Only supported as <!ENTITY ...> outside of <!DOCTYPE ...>
+    // E.g. <!DOCTYPE [ <!ENTITY> ]> will just be a string inside DOCTYPE and not an ENTITY_NODE.
+    PROCESSING_INSTRUCTION_NODE = 7,
+    COMMENT_NODE = 8,
+    DOCUMENT_NODE = 9, // Not used. Root elements are just elements.
+    DOCUMENT_TYPE_NODE = 10,
+    DOCUMENT_FRAGMENT_NODE = 11, // Don't support this either
+    NOTATION_NODE = 12,
+    CLOSE_ELEMENT = 13, // unofficial
+    JSX_ATTRIBUTE = 14, // unofficial
+    JSX = 15 // unofficial
 }

--- a/src/completion/localProvider.ts
+++ b/src/completion/localProvider.ts
@@ -38,7 +38,7 @@ class LocalProvider implements IMavenCompletionItemProvider {
         });
     }
 
-    public async getVersionCandidates(groupId: string, artifactId: string): Promise<vscode.CompletionItem[]>{
+    public async getVersionCandidates(groupId: string, artifactId: string): Promise<vscode.CompletionItem[]> {
         if (!groupId || !artifactId) {
             return [];
         }
@@ -56,7 +56,7 @@ class LocalProvider implements IMavenCompletionItemProvider {
     private async searchForGroupIds(segments: string[]): Promise<string[]> {
         const cwd: string = path.join(this.localRepository, ...segments);
         return new Promise<string[]>((resolve, reject) => {
-            fg.async(["**", "!**/*.*"], { onlyFiles: false, deep: 2, cwd }).then(entries => {
+            fg.async(["**/*/*", "!**/*.*"], { onlyFiles: false, deep: 2, cwd }).then(entries => {
                 const validSegments: string[] = entries.map((e: string) => e.substring(0, e.indexOf("/")));
                 const prefix: string = _.isEmpty(segments) ? "" : [...segments, ""].join(".");
                 const groupIds: string[] = Array.from(new Set(validSegments)).map(seg => `${prefix}${seg}`);


### PR DESCRIPTION
This PR adds additionalTextEdit for artifact ID completion items to achieve the goal.

1. Changed `ElementNode` as we need to know both start/end position of groupId node. 
2. Information of group Id is carried in CompletionItem.data (standard LSP, but not defined in vscode.d.ts)