### PR TITLE
Remove default version in snippets

### DIFF
--- a/src/completion/completionProvider.ts
+++ b/src/completion/completionProvider.ts
@@ -12,8 +12,7 @@ import { localProvider } from "./localProvider";
 const artifactSegments: string[] = [
     "\t<groupId>$1</groupId>",
     "\t<artifactId>$2</artifactId>",
-    // tslint:disable-next-line:no-invalid-template-strings
-    "\t<version>${3:(0.0.0,)}</version>"
+    "\t<version>$3</version>"
 ];
 const dependencySnippet: vscode.SnippetString = new vscode.SnippetString([
     "<dependency>",


### PR DESCRIPTION
A pitfall of using `(0.0.0,)` or `LATEST`: chaos in dependency management. The author can hardly know the resolved version. That's why `LATEST` is deprecated. 

This PR removes the default value, letting users specify it by themselves.