### PR TITLE
Activate extension on opening external pom.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "onCommand:maven.archetype.update",
     "onCommand:maven.history",
     "onCommand:maven.plugin.execute",
-    "onView:mavenProjects"
+    "onView:mavenProjects",
+    "onLanguage:xml"
   ],
   "main": "./dist/extension",
   "contributes": {


### PR DESCRIPTION
For #232 .

In this PR, the extension will be activated if any *.xml file is open. As the completion provider is registered only for pattern `**/pom.xml`, it won't bring any overload for non-pom XML files.

