### PR TITLE
send telemetry when completion item selected

### DIFF
--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -3,11 +3,10 @@
 
 import * as _ from "lodash";
 import * as vscode from "vscode";
+import { COMMAND_COMPLETION_ITEM_SELECTED } from "./constants";
 import { IMavenCompletionItemProvider } from "./IArtifactProvider";
 import { getArtifacts, getVersions } from "./requestUtils";
 import { getSortText } from "./versionUtils";
-
-const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";
 
 class CentralProvider implements IMavenCompletionItemProvider {
     public async getGroupIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -7,6 +7,8 @@ import { IMavenCompletionItemProvider } from "./IArtifactProvider";
 import { getArtifacts, getVersions } from "./requestUtils";
 import { getSortText } from "./versionUtils";
 
+const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";
+
 class CentralProvider implements IMavenCompletionItemProvider {
     public async getGroupIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {
         const keywords: string[] = [...groupIdHint.split("."), ...artifactIdHint.split("-")];
@@ -17,6 +19,10 @@ class CentralProvider implements IMavenCompletionItemProvider {
             const item: vscode.CompletionItem = new vscode.CompletionItem(gid, vscode.CompletionItemKind.Module);
             item.insertText = gid;
             item.detail = "central";
+            item.command = {
+                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                arguments: [{ completeFor: "groupId", source: "maven-central" }]
+            };
             return item;
         });
     }
@@ -30,6 +36,10 @@ class CentralProvider implements IMavenCompletionItemProvider {
             item.insertText = doc.a;
             item.detail = `GroupId: ${doc.g}`;
             (<any>item).data = { groupId: doc.g };
+            item.command = {
+                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                arguments: [{ completeFor: "artifactId", source: "maven-central" }]
+            };
             return item;
         });
     }
@@ -46,6 +56,10 @@ class CentralProvider implements IMavenCompletionItemProvider {
             item.insertText = doc.v;
             item.detail = `Updated: ${new Date(doc.timestamp).toLocaleDateString()}`;
             item.sortText = getSortText(doc.v);
+            item.command = {
+                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                arguments: [{ completeFor: "version", source: "maven-central" }]
+            };
             return item;
         });
     }

--- a/src/completion/centralProvider.ts
+++ b/src/completion/centralProvider.ts
@@ -15,14 +15,15 @@ class CentralProvider implements IMavenCompletionItemProvider {
         const body: any = await getArtifacts(keywords);
         const docs: any[] = _.get(body, "response.docs", []);
         const groupIds: string[] = Array.from(new Set(docs.map(doc => doc.g)).values());
+        const commandOnSelection: vscode.Command = {
+            title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+            arguments: [{ completeFor: "groupId", source: "maven-central" }]
+        };
         return groupIds.map(gid => {
             const item: vscode.CompletionItem = new vscode.CompletionItem(gid, vscode.CompletionItemKind.Module);
             item.insertText = gid;
             item.detail = "central";
-            item.command = {
-                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
-                arguments: [{ completeFor: "groupId", source: "maven-central" }]
-            };
+            item.command = commandOnSelection;
             return item;
         });
     }
@@ -31,15 +32,16 @@ class CentralProvider implements IMavenCompletionItemProvider {
         const keywords: string[] = [...groupIdHint.split("."), ...artifactIdHint.split("-")];
         const body: any = await getArtifacts(keywords);
         const docs: any[] = _.get(body, "response.docs", []);
+        const commandOnSelection: vscode.Command = {
+            title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+            arguments: [{ completeFor: "artifactId", source: "maven-central" }]
+        };
         return docs.map(doc => {
             const item: vscode.CompletionItem = new vscode.CompletionItem(doc.a, vscode.CompletionItemKind.Field);
             item.insertText = doc.a;
             item.detail = `GroupId: ${doc.g}`;
             (<any>item).data = { groupId: doc.g };
-            item.command = {
-                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
-                arguments: [{ completeFor: "artifactId", source: "maven-central" }]
-            };
+            item.command = commandOnSelection;
             return item;
         });
     }
@@ -51,15 +53,16 @@ class CentralProvider implements IMavenCompletionItemProvider {
 
         const body: any = await getVersions(groupId, artifactId);
         const docs: any[] = _.get(body, "response.docs", []);
+        const commandOnSelection: vscode.Command = {
+            title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+            arguments: [{ completeFor: "version", source: "maven-central" }]
+        };
         return docs.map((doc) => {
             const item: vscode.CompletionItem = new vscode.CompletionItem(doc.v, vscode.CompletionItemKind.Constant);
             item.insertText = doc.v;
             item.detail = `Updated: ${new Date(doc.timestamp).toLocaleDateString()}`;
             item.sortText = getSortText(doc.v);
-            item.command = {
-                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
-                arguments: [{ completeFor: "version", source: "maven-central" }]
-            };
+            item.command = commandOnSelection;
             return item;
         });
     }

--- a/src/completion/completionProvider.ts
+++ b/src/completion/completionProvider.ts
@@ -25,6 +25,8 @@ const pluginSnippet: vscode.SnippetString = new vscode.SnippetString([
     "</plugin>$0"
 ].join("\n"));
 
+const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";
+
 class CompletionProvider implements vscode.CompletionItemProvider {
     public localRepository: string = path.join(os.homedir(), ".m2", "repository");
 
@@ -88,12 +90,20 @@ class CompletionProvider implements vscode.CompletionItemProvider {
                 const snippetItem: vscode.CompletionItem = new vscode.CompletionItem("dependency", vscode.CompletionItemKind.Snippet);
                 snippetItem.insertText = dependencySnippet;
                 snippetItem.detail = "Maven Snippet";
+                snippetItem.command = {
+                    title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                    arguments: [{ completeFor: "dependency", source: "snippet" }]
+                };
                 return new vscode.CompletionList([snippetItem], false);
             }
             case XmlTagName.Plugins: {
                 const snippetItem: vscode.CompletionItem = new vscode.CompletionItem("plugin", vscode.CompletionItemKind.Snippet);
                 snippetItem.insertText = pluginSnippet;
                 snippetItem.detail = "Maven Snippet";
+                snippetItem.command = {
+                    title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                    arguments: [{ completeFor: "plugin", source: "snippet" }]
+                };
                 return new vscode.CompletionList([snippetItem], false);
             }
             default:

--- a/src/completion/completionProvider.ts
+++ b/src/completion/completionProvider.ts
@@ -6,6 +6,7 @@ import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { centralProvider } from "./centralProvider";
+import { COMMAND_COMPLETION_ITEM_SELECTED } from "./constants";
 import { ElementNode, getCurrentNode, XmlTagName } from "./lexerUtils";
 import { localProvider } from "./localProvider";
 
@@ -24,8 +25,6 @@ const pluginSnippet: vscode.SnippetString = new vscode.SnippetString([
     ...artifactSegments,
     "</plugin>$0"
 ].join("\n"));
-
-const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";
 
 class CompletionProvider implements vscode.CompletionItemProvider {
     public localRepository: string = path.join(os.homedir(), ".m2", "repository");

--- a/src/completion/constants.ts
+++ b/src/completion/constants.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// tslint:disable-next-line:export-name
+export const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";

--- a/src/completion/localProvider.ts
+++ b/src/completion/localProvider.ts
@@ -9,6 +9,8 @@ import * as vscode from "vscode";
 import { IMavenCompletionItemProvider } from "./IArtifactProvider";
 import { getSortText } from "./versionUtils";
 
+const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";
+
 class LocalProvider implements IMavenCompletionItemProvider {
     public localRepository: string = path.join(os.homedir(), ".m2", "repository");
 
@@ -20,6 +22,10 @@ class LocalProvider implements IMavenCompletionItemProvider {
             const item: vscode.CompletionItem = new vscode.CompletionItem(gid, vscode.CompletionItemKind.Module);
             item.insertText = gid;
             item.detail = "local";
+            item.command = {
+                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                arguments: [{ completeFor: "groupId", source: "maven-local" }]
+            };
             return item;
         });
     }
@@ -34,6 +40,10 @@ class LocalProvider implements IMavenCompletionItemProvider {
             const item: vscode.CompletionItem = new vscode.CompletionItem(aid, vscode.CompletionItemKind.Field);
             item.insertText = aid;
             item.detail = "local";
+            item.command = {
+                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                arguments: [{ completeFor: "artifactId", source: "maven-local" }]
+            };
             return item;
         });
     }
@@ -49,6 +59,10 @@ class LocalProvider implements IMavenCompletionItemProvider {
             item.insertText = v;
             item.detail = "local";
             item.sortText = getSortText(v);
+            item.command = {
+                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+                arguments: [{ completeFor: "version", source: "maven-local" }]
+            };
             return item;
         });
     }

--- a/src/completion/localProvider.ts
+++ b/src/completion/localProvider.ts
@@ -6,10 +6,9 @@ import * as _ from "lodash";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
+import { COMMAND_COMPLETION_ITEM_SELECTED } from "./constants";
 import { IMavenCompletionItemProvider } from "./IArtifactProvider";
 import { getSortText } from "./versionUtils";
-
-const COMMAND_COMPLETION_ITEM_SELECTED: string = "maven.completion.selected";
 
 class LocalProvider implements IMavenCompletionItemProvider {
     public localRepository: string = path.join(os.homedir(), ".m2", "repository");

--- a/src/completion/localProvider.ts
+++ b/src/completion/localProvider.ts
@@ -18,14 +18,15 @@ class LocalProvider implements IMavenCompletionItemProvider {
         const packageSegments: string[] = groupIdHint.split(".");
         packageSegments.pop();
         const validGroupIds: string[] = await this.searchForGroupIds(packageSegments) || [];
+        const commandOnSelection: vscode.Command = {
+            title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+            arguments: [{ completeFor: "groupId", source: "maven-local" }]
+        };
         return validGroupIds.map(gid => {
             const item: vscode.CompletionItem = new vscode.CompletionItem(gid, vscode.CompletionItemKind.Module);
             item.insertText = gid;
             item.detail = "local";
-            item.command = {
-                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
-                arguments: [{ completeFor: "groupId", source: "maven-local" }]
-            };
+            item.command = commandOnSelection;
             return item;
         });
     }
@@ -36,14 +37,15 @@ class LocalProvider implements IMavenCompletionItemProvider {
         }
 
         const validArtifactIds: string[] = await this.searchForArtifactIds(groupId);
+        const commandOnSelection: vscode.Command = {
+            title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+            arguments: [{ completeFor: "artifactId", source: "maven-local" }]
+        };
         return validArtifactIds.map(aid => {
             const item: vscode.CompletionItem = new vscode.CompletionItem(aid, vscode.CompletionItemKind.Field);
             item.insertText = aid;
             item.detail = "local";
-            item.command = {
-                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
-                arguments: [{ completeFor: "artifactId", source: "maven-local" }]
-            };
+            item.command = commandOnSelection;
             return item;
         });
     }
@@ -54,15 +56,16 @@ class LocalProvider implements IMavenCompletionItemProvider {
         }
 
         const validVersions: string[] = await this.searchForVersions(groupId, artifactId);
+        const commandOnSelection: vscode.Command = {
+            title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
+            arguments: [{ completeFor: "version", source: "maven-local" }]
+        };
         return validVersions.map(v => {
             const item: vscode.CompletionItem = new vscode.CompletionItem(v, vscode.CompletionItemKind.Constant);
             item.insertText = v;
             item.detail = "local";
             item.sortText = getSortText(v);
-            item.command = {
-                title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
-                arguments: [{ completeFor: "version", source: "maven-local" }]
-            };
+            item.command = commandOnSelection;
             return item;
         });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@
 "use strict";
 import * as vscode from "vscode";
 import { Progress, Uri } from "vscode";
-import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } from "vscode-extension-telemetry-wrapper";
+import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { ArchetypeModule } from "./archetype/ArchetypeModule";
 import { completionProvider } from "./completion/completionProvider";
 import { OperationCanceledError } from "./Errors";
@@ -139,4 +139,5 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     );
     // completion item provider
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider([{ language: "xml", scheme: "file", pattern: "**/pom.xml" }], completionProvider, ".", "-"));
+    registerCommand(context, "maven.completion.selected", sendInfo, true);
 }


### PR DESCRIPTION
- It calls command `maven.completion.selected` whenever an item is selected.
- It sends `{completeFor: string, source: string}` as the info. 
  - completeFor: dependency/plugin/groupId/artifactId/version
  - source: snippet/maven-local/maven-central
