### PR TITLE
sort for non-strict semantic versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,12 +60,6 @@
             "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
             "dev": true
         },
-        "@types/semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
-            "dev": true
-        },
         "@types/xml2js": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -428,7 +428,6 @@
     "@types/md5": "^2.1.33",
     "@types/minimatch": "^3.0.3",
     "@types/node": "^8.10.39",
-    "@types/semver": "^5.5.0",
     "@types/xml2js": "^0.4.3",
     "ts-loader": "^4.4.2",
     "tslint": "^5.12.1",
@@ -444,7 +443,6 @@
     "lodash": "^4.17.11",
     "md5": "^2.2.1",
     "minimatch": "^3.0.4",
-    "semver": "^5.6.0",
     "vscode-extension-telemetry-wrapper": "0.3.8",
     "xml-zero-lexer": "^2.0.5",
     "xml2js": "^0.4.19"

--- a/src/completion/versionUtils.ts
+++ b/src/completion/versionUtils.ts
@@ -2,13 +2,12 @@
 // Licensed under the MIT license.
 
 import * as _ from "lodash";
-import {parse, SemVer} from "semver";
 
 const VERSION_VALUE_MAX: number = 999;
 const VERSION_VALUE_DIGITS: number = 3;
 // tslint:disable-next-line:export-name
 export function getSortText(version: string): string {
-    const ver: SemVer = parse(version);
-    const versionValues: number[] = ver ? [ver.major, ver.minor, ver.patch] : [0, 0, 0];
-    return versionValues.map(v => _.padStart((VERSION_VALUE_MAX - v).toString(), VERSION_VALUE_DIGITS, "0")).join();
+    const segments: string[] = version.split(/\.|-/);
+    const [major, minor, patch] = segments.map(x => Number.parseInt(x, 10)).map(x => Number.isInteger(x) ? x : 0);
+    return [major, minor, patch].map(v => _.padStart((VERSION_VALUE_MAX - v).toString(), VERSION_VALUE_DIGITS, "0")).join("");
 }


### PR DESCRIPTION
As versions of artifacts from Spring Boot Framework don't strictly follow the semantic version, this PR is supposed to fix #236 by loosely parse the version.