### PR TITLE
Use openExternal to open troubleshooting page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "preview": true,
   "aiKey": "7c4292ac-8ca8-4e02-9f1c-0b73e1eeeca4",
   "engines": {
-    "vscode": "^1.18.0"
+    "vscode": "^1.31.0"
   },
   "categories": [
     "Programming Languages",

--- a/src/utils/uiUtils.ts
+++ b/src/utils/uiUtils.ts
@@ -49,6 +49,6 @@ export async function showTroubleshootingDialog(errorMessage: string): Promise<v
     const choiceForDetails: string = await window.showErrorMessage(errorMessage, OPTION_LEARN_MORE);
     if (choiceForDetails === OPTION_LEARN_MORE) {
         // open FAQs
-        vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(TROUBLESHOOTING_LINK));
+        vscode.env.openExternal(vscode.Uri.parse(TROUBLESHOOTING_LINK));
     }
 }


### PR DESCRIPTION
as suggested by vscode team