### PR TITLE
Refactor: break down utils.

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -57,4 +57,29 @@ export namespace Settings {
     function _getMavenSection<T>(section: string, resource?: Uri): T {
         return workspace.getConfiguration("maven", resource).get<T>(section);
     }
+
+    export function getEnvironment(): {} {
+        const customEnv: any = _getJavaHomeEnvIfAvailable();
+        type EnvironmentSetting = {
+            environmentVariable: string;
+            value: string;
+        };
+        const environmentSettings: EnvironmentSetting[] = Settings.Terminal.customEnv();
+        environmentSettings.forEach((s: EnvironmentSetting) => {
+            customEnv[s.environmentVariable] = s.value;
+        });
+        return customEnv;
+    }
+
+    function _getJavaHomeEnvIfAvailable(): {} {
+        // Look for the java.home setting from the redhat.java extension.  We can reuse it
+        // if it exists to avoid making the user configure it in two places.
+        const javaHome: string = Settings.External.javaHome();
+        const useJavaHome: boolean = Settings.Terminal.useJavaHome();
+        if (useJavaHome && javaHome) {
+            return { JAVA_HOME: javaHome };
+        } else {
+            return {};
+        }
+    }
 }

--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -8,6 +8,7 @@ import { Uri, window, workspace } from "vscode";
 import { instrumentOperationStep, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { OperationCanceledError } from "../Errors";
 import { getPathToExtensionRoot } from "../utils/contextUtils";
+import { executeInTerminal } from "../utils/mavenUtils";
 import { openDialogForFolder } from "../utils/uiUtils";
 import { Utils } from "../utils/Utils";
 import { Archetype } from "./Archetype";
@@ -40,13 +41,13 @@ export namespace ArchetypeModule {
         return cwd;
     }
 
-    async function executeInTerminal(archetypeGroupId: string, archetypeArtifactId: string, cwd: string): Promise<void> {
+    async function executeInTerminalHandler(archetypeGroupId: string, archetypeArtifactId: string, cwd: string): Promise<void> {
         const cmd: string = [
             "archetype:generate",
             `-DarchetypeArtifactId="${archetypeArtifactId}"`,
             `-DarchetypeGroupId="${archetypeGroupId}"`
         ].join(" ");
-        await Utils.executeInTerminal(cmd, null, { cwd });
+        await executeInTerminal(cmd, null, { cwd });
     }
 
     export async function generateFromArchetype(entry: Uri | undefined, operationId: string | undefined): Promise<void> {
@@ -64,7 +65,7 @@ export namespace ArchetypeModule {
         const cwd: string = await instrumentOperationStep(operationId, "chooseTargetFolder", chooseTargetFolder)(targetFolderHint);
 
         // execute in terminal.
-        await instrumentOperationStep(operationId, "executeInTerminal", executeInTerminal)(groupId, artifactId, cwd);
+        await instrumentOperationStep(operationId, "executeInTerminal", executeInTerminalHandler)(groupId, artifactId, cwd);
     }
 
     export async function updateArchetypeCatalog(): Promise<void> {

--- a/src/explorer/model/EffectivePom.ts
+++ b/src/explorer/model/EffectivePom.ts
@@ -1,7 +1,7 @@
-import { Utils } from "../../utils/Utils";
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
+import { Utils } from "../../utils/Utils";
 
 export class EffectivePom {
 

--- a/src/explorer/model/EffectivePom.ts
+++ b/src/explorer/model/EffectivePom.ts
@@ -1,0 +1,36 @@
+import { Utils } from "../../utils/Utils";
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export class EffectivePom {
+
+    public pomPath: string;
+    public raw: string;
+    public data: any;
+    private _updating: boolean;
+
+    constructor(pomPath: string) {
+        this.pomPath = pomPath;
+        this._updating = false;
+    }
+
+    /**
+     * Generate effective pom and parse the data
+     */
+    public async update(): Promise<void> {
+        if (this._updating) {
+            return;
+        }
+
+        this._updating = true;
+        try {
+            this.raw = await Utils.getEffectivePom(this.pomPath);
+            this.data = await Utils.parseXmlContent(this.raw);
+        } catch (error) {
+            console.error(error);
+        }
+        this._updating = false;
+
+    }
+}

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -8,6 +8,7 @@ import { Settings } from "../../Settings";
 import { getPathToExtensionRoot } from "../../utils/contextUtils";
 import { Utils } from "../../utils/Utils";
 import { mavenExplorerProvider } from "../mavenExplorerProvider";
+import { EffectivePom } from "./EffectivePom";
 import { ITreeItem } from "./ITreeItem";
 import { MavenPlugin } from "./MavenPlugin";
 import { PluginsMenu } from "./PluginsMenu";
@@ -16,13 +17,13 @@ const CONTEXT_VALUE: string = "MavenProject";
 
 export class MavenProject implements ITreeItem {
     public parent?: MavenProject;
-    private _rawEffectivePom: string;
-    private _effectivePom: any;
+    private _effectivePom: EffectivePom;
     private _pom: any;
     private _pomPath: string;
 
     constructor(pomPath: string) {
         this._pomPath = pomPath;
+        this._effectivePom = new EffectivePom(pomPath);
     }
 
     public get name(): string {
@@ -37,25 +38,21 @@ export class MavenProject implements ITreeItem {
         return _.get(this._pom, "project.modules[0].module") || [];
     }
 
-    public get rawEffectivePom(): string {
-        return this._rawEffectivePom;
-    }
-
-    public get effectivePom(): string {
+    public get effectivePom(): EffectivePom {
         return this._effectivePom;
     }
 
     public get plugins(): MavenPlugin[] {
         let plugins: any[];
-        if (_.get(this._effectivePom, "projects.project")) {
+        if (_.has(this._effectivePom.data, "projects.project")) {
             // multi-module project
-            const project: any = (<any[]>this._effectivePom.projects.project).find((elem: any) => this.name === _.get(elem, "artifactId[0]"));
+            const project: any = (<any[]>this._effectivePom.data.projects.project).find((elem: any) => this.name === _.get(elem, "artifactId[0]"));
             if (project) {
                 plugins = _.get(project, "build[0].plugins[0].plugin");
             }
         } else {
             // single-project
-            plugins = _.get(this._effectivePom, "project.build[0].plugins[0].plugin");
+            plugins = _.get(this._effectivePom.data, "project.build[0].plugins[0].plugin");
         }
         return this._convertXmlPlugin(plugins);
     }
@@ -92,30 +89,27 @@ export class MavenProject implements ITreeItem {
     public getChildren(): vscode.ProviderResult<ITreeItem[]> {
         const ret: ITreeItem[] = [];
         ret.push(new PluginsMenu(this));
-        if (this.moduleNames.length > 0 && Settings.viewType() === "hierarchical" ) {
+        if (this.moduleNames.length > 0 && Settings.viewType() === "hierarchical") {
             ret.push(...this.modules.map(m => mavenExplorerProvider.getMavenProject(m)));
         }
         return ret;
     }
 
-    public async calculateEffectivePom(force?: boolean): Promise<void> {
-        if (!force && this._rawEffectivePom) {
-            return;
+    public async calculateEffectivePom(force?: boolean): Promise<string> {
+        if (!force && this._effectivePom.raw) {
+            return this._effectivePom.raw;
         }
 
-        this._rawEffectivePom = await Utils.getEffectivePom(this);
-        await this._parseEffectivePom();
+        await this._effectivePom.update();
         mavenExplorerProvider.refresh(this);
-    }
-
-    public async refreshPom(): Promise<void> {
-        await this.parsePom();
-        mavenExplorerProvider.refresh(this);
+        return this._effectivePom.raw;
     }
 
     public async refresh(): Promise<void> {
-        await this.refreshPom();
-        this._rawEffectivePom = undefined;
+        await this._refreshPom();
+        this._effectivePom.update().then(() => {
+            mavenExplorerProvider.refresh(this);
+        }); // no await to unblock the thread.
     }
 
     public async parsePom(): Promise<void> {
@@ -126,12 +120,9 @@ export class MavenProject implements ITreeItem {
         }
     }
 
-    private async _parseEffectivePom(): Promise<void> {
-        try {
-            this._effectivePom = await Utils.parseXmlContent(this._rawEffectivePom);
-        } catch (error) {
-            this._effectivePom = undefined;
-        }
+    private async _refreshPom(): Promise<void> {
+        await this.parsePom();
+        mavenExplorerProvider.refresh(this);
     }
 
     private _convertXmlPlugin(plugins: any[]): MavenPlugin[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { mavenTerminal } from "./mavenTerminal";
 import { Settings } from "./Settings";
 import { taskExecutor } from "./taskExecutor";
 import { getAiKey, getExtensionId, getExtensionVersion, loadPackageInfo } from "./utils/contextUtils";
+import { executeInTerminal } from "./utils/mavenUtils";
 import { openFileIfExists, showTroubleshootingDialog } from "./utils/uiUtils";
 import { Utils } from "./utils/Utils";
 
@@ -65,7 +66,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     context.subscriptions.push(mavenOutputChannel, mavenTerminal, taskExecutor);
     // register commands.
     ["clean", "validate", "compile", "test", "package", "verify", "install", "site", "deploy"].forEach((goal: string) => {
-        registerCommand(context, `maven.goal.${goal}`, async (node: MavenProject) => Utils.executeInTerminal(goal, node.pomPath));
+        registerCommand(context, `maven.goal.${goal}`, async (node: MavenProject) => executeInTerminal(goal, node.pomPath));
     });
     registerCommand(context, "maven.explorer.refresh", async (item?: ITreeItem): Promise<void> => {
         if (item && item.refresh) {
@@ -113,7 +114,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
         if (node &&
             node.name &&
             node.plugin && node.plugin.project && node.plugin.project.pomPath) {
-            Utils.executeInTerminal(node.name, node.plugin.project.pomPath);
+            executeInTerminal(node.name, node.plugin.project.pomPath);
         }
     });
     registerCommand(context, "maven.view.flat", () => Settings.changeToFlatView());

--- a/src/hover/hoverProvider.ts
+++ b/src/hover/hoverProvider.ts
@@ -47,7 +47,7 @@ function getEffectiveVersion(uri: vscode.Uri, gid: string, aid: string): string 
         return undefined;
     }
 
-    const deps: {}[] = _.get(mavenProject.effectivePom, "project.dependencies[0].dependency", []);
+    const deps: {}[] = _.get(mavenProject.effectivePom.data, "project.dependencies[0].dependency", []);
     const targetDep: {} = deps.find(elem => _.get(elem, "groupId[0]") === gid && _.get(elem, "artifactId[0]") === aid);
     return targetDep && _.get(targetDep, "version[0]");
 

--- a/src/mavenTerminal.ts
+++ b/src/mavenTerminal.ts
@@ -5,7 +5,6 @@ import * as vscode from "vscode";
 import { mavenOutputChannel } from "./mavenOutputChannel";
 import { Settings } from "./Settings";
 import { executeCommand } from "./utils/cpUtils";
-import { Utils } from "./utils/Utils";
 
 interface ITerminalOptions {
     addNewLine?: boolean;
@@ -20,7 +19,7 @@ class MavenTerminal implements vscode.Disposable {
         const defaultOptions: ITerminalOptions = { addNewLine: true, name: "Maven" };
         const { addNewLine, name, cwd } = Object.assign(defaultOptions, options);
         if (this.terminals[name] === undefined) {
-            const env: {[envKey: string]: string} = Utils.getEnvironment();
+            const env: {[envKey: string]: string} = Settings.getEnvironment();
             this.terminals[name] = vscode.window.createTerminal({ name, env });
         }
         this.terminals[name].show();

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,33 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as child_process from "child_process";
 import * as fse from "fs-extra";
 import * as http from "http";
 import * as https from "https";
 import * as md5 from "md5";
-import * as path from "path";
 import * as url from "url";
 import { commands, Progress, ProgressLocation, RelativePattern, TextDocument, Uri, ViewColumn, window, workspace, WorkspaceFolder } from "vscode";
 import { createUuid, setUserError } from "vscode-extension-telemetry-wrapper";
 import * as xml2js from "xml2js";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
 import { MavenProject } from "../explorer/model/MavenProject";
-import { mavenOutputChannel } from "../mavenOutputChannel";
-import { mavenTerminal } from "../mavenTerminal";
 import { Settings } from "../Settings";
-import { getExtensionName, getExtensionVersion, getPathToTempFolder } from "./contextUtils";
-
-interface ICommandHistory {
-    pomPath: string;
-    timestamps: { [command: string]: number };
-}
-
-interface ICommandHistoryEntry {
-    command: string;
-    pomPath: string;
-    timestamp: number;
-}
+import { getExtensionVersion, getPathToWorkspaceStorage } from "./contextUtils";
+import { getLRUCommands, ICommandHistoryEntry } from "./historyUtils";
+import { executeInTerminal, pluginDescription, rawEffectivePom } from "./mavenUtils";
 
 export namespace Utils {
 
@@ -56,18 +43,7 @@ export namespace Utils {
     }
 
     function getTempOutputPath(key: string): string {
-        return getPathToTempFolder(getExtensionName(), md5(key), createUuid());
-    }
-
-    function getCommandHistoryCachePath(pomXmlFilePath: string): string {
-        return getPathToTempFolder(getExtensionName(), md5(pomXmlFilePath), "commandHistory.json");
-    }
-
-    export async function readFileIfExists(filepath: string): Promise<string> {
-        if (await fse.pathExists(filepath)) {
-            return (await fse.readFile(filepath)).toString();
-        }
-        return null;
+        return getPathToWorkspaceStorage(md5(key), createUuid());
     }
 
     export async function downloadFile(targetUrl: string, readContent?: boolean, customHeaders?: {}): Promise<string> {
@@ -115,142 +91,6 @@ export namespace Utils {
         });
     }
 
-    async function getMaven(workspaceFolder?: WorkspaceFolder): Promise<string> {
-        if (!workspaceFolder) {
-            return Settings.Executable.path(null) || "mvn";
-        }
-        const executablePathInConf: string = Settings.Executable.path(workspaceFolder.uri);
-        const preferMavenWrapper: boolean = Settings.Executable.preferMavenWrapper(workspaceFolder.uri);
-        if (!executablePathInConf) {
-            const mvnwPathWithoutExt: string = path.join(workspaceFolder.uri.fsPath, "mvnw");
-            if (preferMavenWrapper && await fse.pathExists(mvnwPathWithoutExt)) {
-                return mvnwPathWithoutExt;
-            } else {
-                return "mvn";
-            }
-        } else {
-            return path.resolve(workspaceFolder.uri.fsPath, executablePathInConf);
-        }
-    }
-
-    function wrappedWithQuotes(mvn: string): string {
-        if (mvn === "mvn") {
-            return mvn;
-        } else {
-            return `"${mvn}"`;
-        }
-    }
-
-    export async function executeInTerminal(command: string, pomfile?: string, options?: {}): Promise<void> {
-        const workspaceFolder: WorkspaceFolder = pomfile && workspace.getWorkspaceFolder(Uri.file(pomfile));
-        const mvnString: string = wrappedWithQuotes(await mavenTerminal.formattedPathForTerminal(await getMaven(workspaceFolder)));
-        const fullCommand: string = [
-            mvnString,
-            command.trim(),
-            pomfile && `-f "${await mavenTerminal.formattedPathForTerminal(pomfile)}"`,
-            Settings.Executable.options(pomfile && Uri.file(pomfile))
-        ].filter(Boolean).join(" ");
-        const name: string = workspaceFolder ? `Maven-${workspaceFolder.name}` : "Maven";
-        await mavenTerminal.runInTerminal(fullCommand, Object.assign({ name }, options));
-        if (pomfile) {
-            updateLRUCommands(command, pomfile);
-        }
-    }
-
-    export async function executeInBackground(command: string, pomfile?: string, workspaceFolder?: WorkspaceFolder): Promise<any> {
-        if (!workspaceFolder) {
-            workspaceFolder = pomfile && workspace.getWorkspaceFolder(Uri.file(pomfile));
-        }
-        const mvnExecutable: string = await getMaven(workspaceFolder);
-        const mvnString: string = wrappedWithQuotes(mvnExecutable);
-        // Todo with following line:
-        // 1. pomfile and workspacefolder = undefined, error
-        // 2. non-readable
-        const commandCwd: string = path.resolve(workspaceFolder.uri.fsPath, mvnExecutable, "..");
-
-        const fullCommand: string = [
-            mvnString,
-            command.trim(),
-            pomfile && `-f "${pomfile}"`,
-            Settings.Executable.options(pomfile && Uri.file(pomfile))
-        ].filter(Boolean).join(" ");
-
-        const customEnv: {} = getEnvironment();
-        const execOptions: child_process.ExecOptions = {
-            cwd: commandCwd,
-            env: Object.assign({}, process.env, customEnv)
-        };
-        return new Promise<{}>((resolve: (value: any) => void, reject: (e: Error) => void): void => {
-            mavenOutputChannel.appendLine(fullCommand, "Background Command");
-            child_process.exec(fullCommand, execOptions, (error: Error, stdout: string, _stderr: string): void => {
-                if (error) {
-                    mavenOutputChannel.appendLine(error);
-                    reject(error);
-                } else {
-                    resolve(stdout);
-                }
-            });
-        });
-    }
-
-    export function getEnvironment(): {} {
-        const customEnv: any = getJavaHomeEnvIfAvailable();
-        type EnvironmentSetting = {
-            environmentVariable: string;
-            value: string;
-        };
-        const environmentSettings: EnvironmentSetting[] = Settings.Terminal.customEnv();
-        environmentSettings.forEach((s: EnvironmentSetting) => {
-            customEnv[s.environmentVariable] = s.value;
-        });
-        return customEnv;
-    }
-
-    function getJavaHomeEnvIfAvailable(): {} {
-        // Look for the java.home setting from the redhat.java extension.  We can reuse it
-        // if it exists to avoid making the user configure it in two places.
-        const javaHome: string = Settings.External.javaHome();
-        const useJavaHome: boolean = Settings.Terminal.useJavaHome();
-        if (useJavaHome && javaHome) {
-            return { JAVA_HOME: javaHome };
-        } else {
-            return {};
-        }
-    }
-
-    export async function getLRUCommands(pomPath: string): Promise<ICommandHistoryEntry[]> {
-        const filepath: string = getCommandHistoryCachePath(pomPath);
-        if (await fse.pathExists(filepath)) {
-            const content: string = (await fse.readFile(filepath)).toString();
-            let historyObject: ICommandHistory;
-            try {
-                historyObject = JSON.parse(content);
-            } catch (error) {
-                historyObject = { pomPath, timestamps: {} };
-            }
-            const timestamps: { [command: string]: number } = historyObject.timestamps;
-            const commandList: string[] = Object.keys(timestamps).sort((a, b) => timestamps[b] - timestamps[a]);
-            return commandList.map(command => Object.assign({ command, pomPath, timestamp: timestamps[command] }));
-        }
-        return [];
-    }
-
-    async function updateLRUCommands(command: string, pomPath: string): Promise<void> {
-        const historyFilePath: string = getCommandHistoryCachePath(pomPath);
-        await fse.ensureFile(historyFilePath);
-        const content: string = (await fse.readFile(historyFilePath)).toString();
-        let historyObject: ICommandHistory;
-        try {
-            historyObject = JSON.parse(content);
-            historyObject.pomPath = pomPath;
-        } catch (error) {
-            historyObject = { pomPath, timestamps: {} };
-        } finally {
-            historyObject.timestamps[command] = Date.now();
-        }
-        await fse.writeFile(historyFilePath, JSON.stringify(historyObject));
-    }
-
     export async function getAllPomPaths(workspaceFolder: WorkspaceFolder): Promise<string[]> {
         const exclusions: string[] = Settings.excludedFolders(workspaceFolder.uri);
         const pomFileUris: Uri[] = await workspace.findFiles(new RelativePattern(workspaceFolder, "**/pom.xml"), `{${exclusions.join(",")}}`);
@@ -261,8 +101,7 @@ export namespace Utils {
         let pomxml: string;
         const project: MavenProject = mavenExplorerProvider.getMavenProject(pomPath);
         if (project) {
-            await project.calculateEffectivePom();
-            pomxml = project.rawEffectivePom;
+            pomxml = await project.calculateEffectivePom();
         } else {
             pomxml = await Utils.getEffectivePom(pomPath);
         }
@@ -290,11 +129,7 @@ export namespace Utils {
             async (resolve, reject): Promise<void> => {
                 p.report({ message: `Generating Effective POM: ${name}` });
                 try {
-                    const outputPath: string = getTempOutputPath(pomPath);
-                    await Utils.executeInBackground(`help:effective-pom -Doutput="${outputPath}"`, pomPath);
-                    const pomxml: string = await Utils.readFileIfExists(outputPath);
-                    await fse.remove(outputPath);
-                    return resolve(pomxml);
+                    return resolve(rawEffectivePom(pomPath));
                 } catch (error) {
                     setUserError(error);
                     return reject(error);
@@ -307,13 +142,8 @@ export namespace Utils {
         return await window.withProgress({ location: ProgressLocation.Window }, (p: Progress<{ message?: string }>) => new Promise<string>(
             async (resolve, reject): Promise<void> => {
                 p.report({ message: `Retrieving Plugin Info: ${pluginId}` });
-                const outputPath: string = getTempOutputPath(pluginId);
                 try {
-                    // For MacOSX, add "-Dapple.awt.UIElement=true" to prevent showing icons in dock
-                    await Utils.executeInBackground(`help:describe -Dapple.awt.UIElement=true -Dplugin=${pluginId} -Doutput="${outputPath}"`, pomPath);
-                    const content: string = await Utils.readFileIfExists(outputPath);
-                    await fse.remove(outputPath);
-                    return resolve(content);
+                    return resolve(pluginDescription(pluginId, pomPath));
                 } catch (error) {
                     setUserError(error);
                     return reject(error);
@@ -329,14 +159,14 @@ export namespace Utils {
         const inputGoals: string = await window.showInputBox({ placeHolder: "e.g. clean package -DskipTests", ignoreFocusOut: true });
         const trimmedGoals: string = inputGoals && inputGoals.trim();
         if (trimmedGoals) {
-            Utils.executeInTerminal(trimmedGoals, pomPath);
+            executeInTerminal(trimmedGoals, pomPath);
         }
     }
 
     export async function executeHistoricalGoals(projectPomPaths: string[]): Promise<void> {
         const candidates: ICommandHistoryEntry[] = Array.prototype.concat.apply(
             [],
-            await Promise.all(projectPomPaths.map(projectPomPath => Utils.getLRUCommands(projectPomPath)))
+            await Promise.all(projectPomPaths.map(getLRUCommands))
         );
         candidates.sort((a, b) => b.timestamp - a.timestamp);
         const selected: { command: string; pomPath: string; timestamp: number } = await window.showQuickPick(
@@ -349,7 +179,7 @@ export namespace Utils {
             { placeHolder: "Select from history ...", ignoreFocusOut: true }
         ).then(item => item && item.value);
         if (selected) {
-            Utils.executeInTerminal(selected.command, selected.pomPath);
+            executeInTerminal(selected.command, selected.pomPath);
         }
     }
 

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -4,14 +4,17 @@
 import * as fse from "fs-extra";
 import * as os from "os";
 import * as path from "path";
-import { ExtensionContext,  extensions } from "vscode";
+import { ExtensionContext, extensions } from "vscode";
 
+let EXTENSION_CONTEXT: ExtensionContext;
 let EXTENSION_PUBLISHER: string;
 let EXTENSION_NAME: string;
 let EXTENSION_VERSION: string;
 let EXTENSION_AI_KEY: string;
 
 export async function loadPackageInfo(context: ExtensionContext): Promise<void> {
+    EXTENSION_CONTEXT = context;
+
     const { publisher, name, version, aiKey } = await fse.readJSON(context.asAbsolutePath("./package.json"));
     EXTENSION_AI_KEY = aiKey;
     EXTENSION_PUBLISHER = publisher;
@@ -45,4 +48,9 @@ export function getPathToTempFolder(...args: string[]): string {
 
 export function getPathToExtensionRoot(...args: string[]): string {
     return path.join(extensions.getExtension(getExtensionId()).extensionPath, ...args);
+}
+
+export function getPathToWorkspaceStorage(...args: string[]): string {
+    fse.ensureDirSync(EXTENSION_CONTEXT.storagePath);
+    return path.join(EXTENSION_CONTEXT.storagePath, ...args);
 }

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -3,9 +3,11 @@
 
 import * as cp from "child_process";
 import * as vscode from "vscode";
+import { mavenOutputChannel } from "../mavenOutputChannel";
 
 export async function executeCommand(command: string, args: string[], options: cp.SpawnOptions = { shell: true }): Promise<string> {
     return new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
+        mavenOutputChannel.appendLine(`${command}, [${args.join(",")}]`);
         let result: string = "";
         const childProc: cp.ChildProcess = cp.spawn(command, args, options);
         childProc.stdout.on("data", (data: string | Buffer) => {
@@ -26,6 +28,7 @@ export async function executeCommand(command: string, args: string[], options: c
 export async function executeCommandWithProgress(message: string, command: string, args: string[], options: cp.SpawnOptions = { shell: true }): Promise<string> {
     let result: string = "";
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (p: vscode.Progress<{}>) => {
+        mavenOutputChannel.appendLine(`${command}, [${args.join(",")}]`);
         return new Promise(async (resolve: () => void, reject: (e: Error) => void): Promise<void> => {
             p.report({ message });
             try {

--- a/src/utils/historyUtils.ts
+++ b/src/utils/historyUtils.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as fse from "fs-extra";
+import * as md5 from "md5";
+import { getExtensionName, getPathToTempFolder } from "./contextUtils";
+
+export interface ICommandHistory {
+    pomPath: string;
+    timestamps: { [command: string]: number };
+}
+
+export interface ICommandHistoryEntry {
+    command: string;
+    pomPath: string;
+    timestamp: number;
+}
+
+export async function updateLRUCommands(command: string, pomPath: string): Promise<void> {
+    const historyFilePath: string = getCommandHistoryCachePath(pomPath);
+    await fse.ensureFile(historyFilePath);
+    const content: string = (await fse.readFile(historyFilePath)).toString();
+    let historyObject: ICommandHistory;
+    try {
+        historyObject = JSON.parse(content);
+        historyObject.pomPath = pomPath;
+    } catch (error) {
+        historyObject = { pomPath, timestamps: {} };
+    } finally {
+        historyObject.timestamps[command] = Date.now();
+    }
+    await fse.writeFile(historyFilePath, JSON.stringify(historyObject));
+}
+
+export async function getLRUCommands(pomPath: string): Promise<ICommandHistoryEntry[]> {
+    const filepath: string = getCommandHistoryCachePath(pomPath);
+    if (await fse.pathExists(filepath)) {
+        const content: string = (await fse.readFile(filepath)).toString();
+        let historyObject: ICommandHistory;
+        try {
+            historyObject = JSON.parse(content);
+        } catch (error) {
+            historyObject = { pomPath, timestamps: {} };
+        }
+        const timestamps: { [command: string]: number } = historyObject.timestamps;
+        const commandList: string[] = Object.keys(timestamps).sort((a, b) => timestamps[b] - timestamps[a]);
+        return commandList.map(command => Object.assign({ command, pomPath, timestamp: timestamps[command] }));
+    }
+    return [];
+}
+
+function getCommandHistoryCachePath(pomXmlFilePath: string): string {
+    return getPathToTempFolder(getExtensionName(), md5(pomXmlFilePath), "commandHistory.json");
+}

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as child_process from "child_process";
+import * as fse from "fs-extra";
+import * as md5 from "md5";
+import * as path from "path";
+import * as vscode from "vscode";
+import { mavenOutputChannel } from "../mavenOutputChannel";
+import { mavenTerminal } from "../mavenTerminal";
+import { Settings } from "../Settings";
+import { getPathToWorkspaceStorage } from "./contextUtils";
+import { updateLRUCommands } from "./historyUtils";
+
+export async function rawEffectivePom(pomPath: string): Promise<string> {
+    const outputPath: string = getPathToWorkspaceStorage(md5(pomPath));
+    await executeInBackground(`help:effective-pom -Doutput="${outputPath}"`, pomPath);
+    const pomxml: string = await readFileIfExists(outputPath);
+    await fse.remove(outputPath);
+    return pomxml;
+}
+
+export async function pluginDescription(pluginId: string, pomPath: string): Promise<string> {
+    const outputPath: string = getPathToWorkspaceStorage(md5(pluginId));
+    // For MacOSX, add "-Dapple.awt.UIElement=true" to prevent showing icons in dock
+    await executeInBackground(`help:describe -Dapple.awt.UIElement=true -Dplugin=${pluginId} -Doutput="${outputPath}"`, pomPath);
+    const content: string = await readFileIfExists(outputPath);
+    await fse.remove(outputPath);
+    return content;
+}
+
+export async function executeInBackground(command: string, pomfile?: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<any> {
+    if (!workspaceFolder) {
+        workspaceFolder = pomfile && vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pomfile));
+    }
+    const mvnExecutable: string = await getMaven(workspaceFolder);
+    const mvnString: string = wrappedWithQuotes(mvnExecutable);
+    // Todo with following line:
+    // 1. pomfile and workspacefolder = undefined, error
+    // 2. non-readable
+    const commandCwd: string = path.resolve(workspaceFolder.uri.fsPath, mvnExecutable, "..");
+
+    const fullCommand: string = [
+        mvnString,
+        command.trim(),
+        pomfile && `-f "${pomfile}"`,
+        Settings.Executable.options(pomfile && vscode.Uri.file(pomfile))
+    ].filter(Boolean).join(" ");
+
+    const customEnv: {} = Settings.getEnvironment();
+    const execOptions: child_process.ExecOptions = {
+        cwd: commandCwd,
+        env: Object.assign({}, process.env, customEnv)
+    };
+    return new Promise<{}>((resolve: (value: any) => void, reject: (e: Error) => void): void => {
+        mavenOutputChannel.appendLine(fullCommand);
+        child_process.exec(fullCommand, execOptions, (error: Error, stdout: string, _stderr: string): void => {
+            if (error) {
+                mavenOutputChannel.appendLine(error);
+                reject(error);
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+}
+
+export async function executeInTerminal(command: string, pomfile?: string, options?: {}): Promise<void> {
+    const workspaceFolder: vscode.WorkspaceFolder = pomfile && vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pomfile));
+    const mvnString: string = wrappedWithQuotes(await mavenTerminal.formattedPathForTerminal(await getMaven(workspaceFolder)));
+    const fullCommand: string = [
+        mvnString,
+        command.trim(),
+        pomfile && `-f "${await mavenTerminal.formattedPathForTerminal(pomfile)}"`,
+        Settings.Executable.options(pomfile && vscode.Uri.file(pomfile))
+    ].filter(Boolean).join(" ");
+    const name: string = workspaceFolder ? `Maven-${workspaceFolder.name}` : "Maven";
+    await mavenTerminal.runInTerminal(fullCommand, Object.assign({ name }, options));
+    if (pomfile) {
+        updateLRUCommands(command, pomfile);
+    }
+}
+
+async function getMaven(workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
+    if (!workspaceFolder) {
+        return Settings.Executable.path(null) || "mvn";
+    }
+    const executablePathInConf: string = Settings.Executable.path(workspaceFolder.uri);
+    const preferMavenWrapper: boolean = Settings.Executable.preferMavenWrapper(workspaceFolder.uri);
+    if (!executablePathInConf) {
+        const mvnwPathWithoutExt: string = path.join(workspaceFolder.uri.fsPath, "mvnw");
+        if (preferMavenWrapper && await fse.pathExists(mvnwPathWithoutExt)) {
+            return mvnwPathWithoutExt;
+        } else {
+            return "mvn";
+        }
+    } else {
+        return path.resolve(workspaceFolder.uri.fsPath, executablePathInConf);
+    }
+}
+
+function wrappedWithQuotes(mvn: string): string {
+    if (mvn === "mvn") {
+        return mvn;
+    } else {
+        return `"${mvn}"`;
+    }
+}
+
+async function readFileIfExists(filepath: string): Promise<string> {
+    if (await fse.pathExists(filepath)) {
+        return (await fse.readFile(filepath)).toString();
+    }
+    return null;
+}


### PR DESCRIPTION
Break down `Utils` into:
- contextUtils: Context related utils, path calculation, etc. 
- cpUtils: execute external process
- historyUtils: maven goal history related, LRU cache
- mavenUtils: execute background maven command to get string output, e.g. effective pom, plugin description

Extract EffectivePom as a class.