### PR TITLE
Hide maven.plugin.execute from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,10 @@
         {
           "command": "maven.project.openPom",
           "when": "never"
+        },
+        {
+          "command": "maven.plugin.execute",
+          "when": "never"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
Previously this command is shown in command palette. But without any parameter, it cannot be successfully executed. 