### PR TITLE
Change wording of custom goals for consistency

### DIFF
--- a/TestPlan.md
+++ b/TestPlan.md
@@ -35,7 +35,7 @@
 
 ### Execute custom goals
 1. Right-click on project item
-1. Click `Custom goals ... `
+1. Click `Custom ... `
 1. Input a valid string of goals, e.g. `clean package -DskipTests`, press `Enter`.
 1. Verify: 
     1. It execute the corresponding maven command.
@@ -198,7 +198,7 @@ The tree view of maven projects should update when any pom.xml is created/modifi
 1. Open `User Settings`.
 2. Check supported platforms and terminals in [README](https://github.com/Eskibear/vscode-maven/blob/develop/README.md)
 3. Change value of `terminal.integrated.shell.windows/linux/osx` according to the targeted system and terminal.
-4. Test `Custom goals ...`, `Generate project from Maven Archetype` and `Effective POM`.
+4. Test `Custom ...`, `Generate project from Maven Archetype` and `Effective POM`.
 5. Verify: 
     1. Commands can be successfully executed in above tasks.
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
     "description": "Manage Maven projects, execute goals, generate project from archetype, improve user experience for Java developers.",
     "contributes.commands.maven.explorer.refresh": "Refresh",
-    "contributes.commands.maven.goal.custom": "Custom goals ... ",
+    "contributes.commands.maven.goal.custom": "Custom ... ",
     "contributes.commands.maven.project.effectivePom": "Show Effective POM",
     "contributes.commands.maven.project.openPom": "Open POM file",
     "contributes.commands.maven.archetype.generate": "Generate from Maven Archetype",

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -204,7 +204,7 @@ export namespace Utils {
             return;
         }
 
-        const LABEL_CUSTOM: string = "Custom goals ...";
+        const LABEL_CUSTOM: string = "Custom ...";
         const LABEL_FAVORITES: string = "Favorites ...";
         // select a command
         const selectedCommand: string = await window.showQuickPick(


### PR DESCRIPTION
`Custom goals ...`  to `Custom ...`

It's now consistent with "History ..." and "Favorites ..."

![image](https://user-images.githubusercontent.com/2351748/53713864-563f3200-3e87-11e9-9cb5-1875c8ec1714.png)
