### PR TITLE
Fix NPE when no workspace open

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -12,7 +12,7 @@ import * as xml2js from "xml2js";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
 import { MavenProject } from "../explorer/model/MavenProject";
 import { Settings } from "../Settings";
-import { getExtensionVersion, getPathToWorkspaceStorage } from "./contextUtils";
+import { getExtensionVersion, getPathToWorkspaceStorage, getPathToTempFolder } from "./contextUtils";
 import { getLRUCommands, ICommandHistoryEntry } from "./historyUtils";
 import { executeInTerminal, pluginDescription, rawEffectivePom } from "./mavenUtils";
 
@@ -43,7 +43,12 @@ export namespace Utils {
     }
 
     function getTempOutputPath(key: string): string {
-        return getPathToWorkspaceStorage(md5(key), createUuid());
+        const pathInWorkspaceFolder: string = getPathToWorkspaceStorage(md5(key), createUuid());
+        if (pathInWorkspaceFolder !== undefined) {
+            return pathInWorkspaceFolder;
+        } else {
+            return getPathToTempFolder(md5(key), createUuid());
+        }
     }
 
     export async function downloadFile(targetUrl: string, readContent?: boolean, customHeaders?: {}): Promise<string> {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -12,7 +12,7 @@ import * as xml2js from "xml2js";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
 import { MavenProject } from "../explorer/model/MavenProject";
 import { Settings } from "../Settings";
-import { getExtensionVersion, getPathToWorkspaceStorage, getPathToTempFolder } from "./contextUtils";
+import { getExtensionVersion, getPathToTempFolder, getPathToWorkspaceStorage } from "./contextUtils";
 import { getLRUCommands, ICommandHistoryEntry } from "./historyUtils";
 import { executeInTerminal, pluginDescription, rawEffectivePom } from "./mavenUtils";
 

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -51,6 +51,9 @@ export function getPathToExtensionRoot(...args: string[]): string {
 }
 
 export function getPathToWorkspaceStorage(...args: string[]): string {
+    if (EXTENSION_CONTEXT.storagePath === undefined) {
+        return undefined;
+    }
     fse.ensureDirSync(EXTENSION_CONTEXT.storagePath);
     return path.join(EXTENSION_CONTEXT.storagePath, ...args);
 }


### PR DESCRIPTION
If no workspace is open, the temp file path is not valid.