### PR TITLE
Add shortcut to show raw dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,11 @@
         "category": "Maven"
       },
       {
+        "command": "maven.project.showDependencies",
+        "title": "%contributes.commands.maven.project.showDependencies%",
+        "category": "Maven"
+      },
+      {
         "command": "maven.favorites",
         "title": "Favorites ...",
         "category": "Maven"
@@ -351,6 +356,11 @@
           "command": "maven.project.effectivePom",
           "when": "view == mavenProjects && viewItem == MavenProject",
           "group": "0-pom@1"
+        },
+        {
+          "command": "maven.project.showDependencies",
+          "when": "view == mavenProjects && viewItem == MavenProject",
+          "group": "0-pom@0"
         },
         {
           "command": "maven.plugin.execute",

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,6 +13,7 @@
     "contributes.commands.maven.view.hierarchical": "Switch to hierarchical view",
     "contributes.commands.maven.view.flat": "Switch to flat view",
     "contributes.commands.maven.project.addDependency": "Add a dependency",
+    "contributes.commands.maven.project.showDependencies": "Show dependencies",
     "contributes.views.explorer.mavenProjects": "Maven Projects",
     "configuration.maven.excludedFolders": "Specifies file path pattern of folders to exclude while searching for Maven projects.",
     "configuration.maven.executable.preferMavenWrapper": "Specifies whether you prefer to use Maven wrapper. If true, it tries using 'mvnw' in root folder by default if the file configuration exists. Otherwise it tries 'mvn' in PATH instead.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { pluginInfoProvider } from "./explorer/pluginInfoProvider";
 import { addDependencyHandler } from "./handlers/addDependencyHandler";
 import { debugHandler } from "./handlers/debugHandler";
 import { runFavoriteCommandsHandler } from "./handlers/runFavoriteCommandsHandler";
+import { showDependenciesHandler } from "./handlers/showDependenciesHandler";
 import { hoverProvider } from "./hover/hoverProvider";
 import { mavenOutputChannel } from "./mavenOutputChannel";
 import { mavenTerminal } from "./mavenTerminal";
@@ -118,11 +119,11 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     // completion item provider
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(pomSelector, completionProvider, ".", "-"));
     registerCommand(context, "maven.completion.selected", sendInfo, true);
-
+    // dependency
     registerCommand(context, "maven.project.addDependency", async () => await addDependencyHandler());
+    registerCommand(context, "maven.project.showDependencies", async (project: MavenProject) => await showDependenciesHandler(project));
     // hover
     context.subscriptions.push(vscode.languages.registerHoverProvider(pomSelector, hoverProvider));
-
     // debug
     registerCommand(context, "maven.plugin.debug", debugHandler);
     vscode.debug.onDidTerminateDebugSession((session: any) => {

--- a/src/handlers/showDependenciesHandler.ts
+++ b/src/handlers/showDependenciesHandler.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import { setUserError } from "vscode-extension-telemetry-wrapper";
+import { MavenProject } from "../explorer/model/MavenProject";
+import { rawDependencyTree } from "../utils/mavenUtils";
+
+export async function showDependenciesHandler(project: MavenProject): Promise<void> {
+    const treeContent: string = (await getDependencyTree(project)).replace(/\|/g, " ");
+    const document: vscode.TextDocument = await vscode.workspace.openTextDocument({ language: "diff", content: treeContent });
+    await vscode.window.showTextDocument(document, { viewColumn: vscode.ViewColumn.Active, preview: false });
+}
+
+async function getDependencyTree(pomPathOrMavenProject: string | MavenProject): Promise<string> {
+    let pomPath: string;
+    let name: string;
+    if (typeof pomPathOrMavenProject === "object" && pomPathOrMavenProject instanceof MavenProject) {
+        const mavenProject: MavenProject = <MavenProject>pomPathOrMavenProject;
+        pomPath = mavenProject.pomPath;
+        name = mavenProject.name;
+    } else if (typeof pomPathOrMavenProject === "string") {
+        pomPath = pomPathOrMavenProject;
+        name = pomPath;
+    } else {
+        return undefined;
+    }
+    return await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async (p: vscode.Progress<{ message?: string }>) => new Promise<string>(
+        async (resolve, reject): Promise<void> => {
+            p.report({ message: `Generating Dependency Tree: ${name}` });
+            try {
+                resolve(rawDependencyTree(pomPath));
+                return;
+            } catch (error) {
+                setUserError(<Error>error);
+                reject(error);
+                return;
+            }
+        }
+    ));
+}

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -20,6 +20,14 @@ export async function rawEffectivePom(pomPath: string): Promise<string> {
     return pomxml;
 }
 
+export async function rawDependencyTree(pomPath: string): Promise<string> {
+    const outputPath: string = getPathToWorkspaceStorage(md5(pomPath));
+    await executeInBackground(`dependency:tree -Dverbose -DoutputFile="${outputPath}"`, pomPath);
+    const pomxml: string = await readFileIfExists(outputPath);
+    await fse.remove(outputPath);
+    return pomxml;
+}
+
 export async function pluginDescription(pluginId: string, pomPath: string): Promise<string> {
     const outputPath: string = getPathToWorkspaceStorage(md5(pluginId));
     // For MacOSX, add "-Dapple.awt.UIElement=true" to prevent showing icons in dock


### PR DESCRIPTION
1. Run mvn dependency:tree in background to get raw tree.
2. Replace exec with spawn to get rid of max buffer issue.

![depetree](https://user-images.githubusercontent.com/2351748/55054940-6f10c100-509c-11e9-8496-30804d1dd86f.gif)
