### PR TITLE
Fix a typo in TestPlan

### DIFF
--- a/TestPlan.md
+++ b/TestPlan.md
@@ -57,7 +57,7 @@
 1. Specify a favorite command in settings, e.g.
     ```
         {
-            "maven.terminal.favorite": [
+            "maven.terminal.favorites": [
                 {
                     "alias": "full-build without tests",
                     "command": "clean package -DskipTests"


### PR DESCRIPTION
The setting config example is wrong. I came across this example when I was trying to set up my maven favorite commands. I got errors until I realize the correct setting field should be "maven.terminal.favorite**s**"