### PR TITLE
Fix potential infinite execution loop of calculating effective-pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to the "vscode-maven" extension will be documented in this f
 
 ## 0.16.1
 #### Fixed 
-- An error on calculating effective pom when whitespace in project path. [#304](https://github.com/Microsoft/vscode-maven/issues/304)
+- An error on calculating effective pom when there is whitespace in project path. [#304](https://github.com/Microsoft/vscode-maven/issues/304)
+- A bug which causes to retry calculating effective pom all the time. [#296](https://github.com/Microsoft/vscode-maven/issues/296)
 
 ## 0.16.0
 #### Added

--- a/src/explorer/model/EffectivePom.ts
+++ b/src/explorer/model/EffectivePom.ts
@@ -29,9 +29,9 @@ export class EffectivePom {
             this.raw = silent ? await rawEffectivePom(this.pomPath) : await Utils.getEffectivePom(this.pomPath);
             this.data = await Utils.parseXmlContent(this.raw ? this.raw : "");
         } catch (error) {
-            console.error(error);
+            throw error;
+        } finally {
+            this._updating = false;
         }
-        this._updating = false;
-
     }
 }

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -104,9 +104,14 @@ export class MavenProject implements ITreeItem {
             return this._effectivePom.raw;
         }
 
-        await this._effectivePom.update();
-        mavenExplorerProvider.refresh(this);
-        return this._effectivePom.raw;
+        try {
+            await this._effectivePom.update();
+            mavenExplorerProvider.refresh(this);
+        } catch (error) {
+            console.error(error);
+        } finally {
+            return this._effectivePom.raw;
+        }
     }
 
     public async refresh(): Promise<void> {


### PR DESCRIPTION
For some reason it's possible to fail to calculate the effective pom. Previously if user expand the "Plugins" node, it requires to calculate the effective pom (but fail), and `mavenExplorerProvider.refresh(this);` always re-triggers the calculation. 

Related issue #296 