### PR TITLE
Fix unexpected insertion of code snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the "vscode-maven" extension will be documented in this file.
 
+#### Fixed
+- Unexpected insertion of code snippets. [#310](https://github.com/microsoft/vscode-maven/issues/310)
+
 ## 0.16.2
 #### Fixed
 - A regression issue which blocks auto-completion for pom files. [#311](https://github.com/Microsoft/vscode-maven/issues/311)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
         pattern: Settings.Pomfile.globPattern(),
     }];
     // completion item provider
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(pomSelector, completionProvider, ".", "-"));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(pomSelector, completionProvider, ".", "-", "<"));
     registerCommand(context, "maven.completion.selected", sendInfo, true);
     // dependency
     registerCommand(context, "maven.project.addDependency", async () => await addDependencyHandler());


### PR DESCRIPTION
See: #310 

This PR improves experience of inserting code snippets by 
- adding "<" as trigger char.
- removing unexpected brackets.


### a) Trigger by char "<"
#### Prev
![old_dep_char](https://user-images.githubusercontent.com/2351748/57499714-46265180-7313-11e9-8132-9128497509be.gif)

#### Now
![new_dep_char](https://user-images.githubusercontent.com/2351748/57499724-4cb4c900-7313-11e9-9a74-b13caf294088.gif)
### b) Trigger by manual invoke, e.g. `ctrl+space` short key
#### Prev
![old_dep_invo](https://user-images.githubusercontent.com/2351748/57499717-47f01500-7313-11e9-8343-8817b45abf7f.gif)
#### Now
![new_dep_invo](https://user-images.githubusercontent.com/2351748/57499726-4d4d5f80-7313-11e9-9b6c-3998ba59c2df.gif)
