### PR TITLE
Escape square brackets in path in PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the "vscode-maven" extension will be documented in this f
 
 #### Fixed
 - Unexpected insertion of code snippets. [#310](https://github.com/microsoft/vscode-maven/issues/310)
+- Cannot create Maven project when target directory has brackets and default shell is PowerShell. [#324](https://github.com/microsoft/vscode-maven/issues/324)
 
 ## 0.16.2
 #### Fixed

--- a/src/mavenTerminal.ts
+++ b/src/mavenTerminal.ts
@@ -101,7 +101,10 @@ async function getCDCommand(cwd: string): Promise<string> {
             case WindowsShellType.GIT_BASH:
                 return `cd "${cwd.replace(/\\+$/, "")}"`; // Git Bash: remove trailing '\'
             case WindowsShellType.POWER_SHELL:
-                return `cd "${cwd}"`; // PowerShell
+                // Escape '[' and ']' in PowerShell
+                // See: https://github.com/microsoft/vscode-maven/issues/324
+                const escaped: string = cwd.replace(/([\[\]])/g, "``$1");
+                return `cd "${escaped}"`; // PowerShell
             case WindowsShellType.CMD:
                 return `cd /d "${cwd}"`; // CMD
             case WindowsShellType.WSL:


### PR DESCRIPTION
See #324 
This PR serves as a workaround to escape `[` and `]` in Powershell. 

It works for me. 
```powershell
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Try the new cross-platform PowerShell https://aka.ms/pscore6

PS C:\WINDOWS\System32\WindowsPowerShell\v1.0> cd "c:\Users\yanzh\Desktop\play\``[demo``]\demo-maven"
PS C:\Users\yanzh\Desktop\play\[demo]\demo-maven> cmd /c mvn archetype:generate -DarchetypeArtifactId="azure-maven-archetypes" -DarchetypeGroupId="com.microsoft.azure"
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-war-plugin/3.1.0/maven-war-plugin-3.1.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-war-plugin/3.1.0/maven-war-plugin-3.1.0.pom (9.3 kB at 5.7 kB/s)
```