### PR TITLE
Allow to specify whether to auto-update EffectivePOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -493,6 +493,12 @@
             "default": "**/pom.xml",
             "description": "%configuration.maven.pomfile.globPattern%",
             "scope": "window"
+          },
+          "maven.pomfile.autoUpdateEffectivePOM": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.maven.pomfile.autoUpdateEffectivePOM%",
+            "scope": "window"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,7 @@
     "configuration.maven.executable.preferMavenWrapper": "Specifies whether you prefer to use Maven wrapper. If true, it tries using 'mvnw' in root folder by default if the file configuration exists. Otherwise it tries 'mvn' in PATH instead.",
     "configuration.maven.executable.path": "Specifies absolute path of your mvn executable. When this value is empty, it tries using 'mvn' or 'mvnw' according to value of 'maven.executable.preferMavenWrapper'. Note that a relative path is not suggested, but if you do specify one, the absolute path will be resolved from your workspace root folder (if exists). ",
     "configuration.maven.executable.options": "Specifies default options for all mvn commands.",
+    "configuration.maven.pomfile.autoUpdateEffectivePOM": "Specifies whether to update effective-pom automatically whenever changes detected.",
     "configuration.maven.pomfile.globPattern": "Specifies the glob pattern used to look for pom.xml files.",
     "configuration.maven.terminal.useJavaHome": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
     "configuration.maven.terminal.customEnv": "Specifies an array of environment variable names and values. These environment variable values will be added to the terminal session before Maven is first executed.",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -19,6 +19,7 @@
     "configuration.maven.executable.preferMavenWrapper": "指定是否优先使用 Maven Wrapper。如果为 true，则尝试使用根文件夹下的 mvnw 作为可执行文件；否则尝试使用系统 PATH 中的 mvn。",
     "configuration.maven.executable.path": "指定mvn可执行文件的绝对路径。当此值为空时，它会根据 maven.executable.preferMavenWrapper 的值尝试使用 mvn 或 mvnw 。请注意，不建议使用相对路径，但如果指定了相对路径，则将从工作区根文件夹（如果存在）中解析绝对路径。",
     "configuration.maven.executable.options": "指定所有mvn命令的默认选项。",
+    "configuration.maven.pomfile.autoUpdateEffectivePOM": "指定是否自动更新有效的 POM。",
     "configuration.maven.pomfile.globPattern": "指定用于查找 POM 文件的 glob 模式。",
     "configuration.maven.terminal.useJavaHome": "如果此值为 true ，并且配置项 java.home 具有值，则在创建新的终端窗口时，将环境变量 JAVA_HOME 设置为 java.home 的值。",
     "configuration.maven.terminal.customEnv": "自定义环境变量。在首次执行 Maven 之前，这些环境变量值将被添加到终端会话中。",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -60,6 +60,10 @@ export namespace Settings {
     }
 
     export namespace Pomfile {
+        export function autoUpdateEffectivePOM(): boolean {
+            return !!_getMavenSection<boolean>("pomfile.autoUpdateEffectivePOM");
+        }
+
         export function globPattern(): string {
             const ret: string | undefined = _getMavenSection<string>("pomfile.globPattern");
             return ret !== undefined ? ret : "**/pom.xml";

--- a/src/explorer/model/EffectivePom.ts
+++ b/src/explorer/model/EffectivePom.ts
@@ -9,11 +9,14 @@ export class EffectivePom {
     public pomPath: string;
     public raw: string | undefined;
     public data: any;
+    public upToDate: boolean;
+
     private _updating: boolean;
 
     constructor(pomPath: string) {
         this.pomPath = pomPath;
         this._updating = false;
+        this.upToDate = false;
     }
 
     /**
@@ -28,6 +31,7 @@ export class EffectivePom {
         try {
             this.raw = silent ? await rawEffectivePom(this.pomPath) : await Utils.getEffectivePom(this.pomPath);
             this.data = await Utils.parseXmlContent(this.raw ? this.raw : "");
+            this.upToDate = true;
         } catch (error) {
             throw error;
         } finally {

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -120,10 +120,6 @@ export class MavenProject implements ITreeItem {
 
     public async refresh(): Promise<void> {
         await this._refreshPom();
-        this._effectivePom.update()
-        .then(() => {
-            mavenExplorerProvider.refresh(this);
-        }).catch(console.error); // no await to unblock the thread.
     }
 
     public async parsePom(): Promise<void> {

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -104,7 +104,7 @@ export class MavenProject implements ITreeItem {
     }
 
     public async calculateEffectivePom(force?: boolean): Promise<string | undefined> {
-        if (!force && this._effectivePom.raw) {
+        if (!force && this._effectivePom.upToDate) {
             return this._effectivePom.raw;
         }
 

--- a/src/explorer/model/PluginsMenu.ts
+++ b/src/explorer/model/PluginsMenu.ts
@@ -7,6 +7,7 @@ import { ITreeItem } from "./ITreeItem";
 import { MavenPlugin } from "./MavenPlugin";
 import { MavenProject } from "./MavenProject";
 import { Menu } from "./Menu";
+import { mavenExplorerProvider } from "../mavenExplorerProvider";
 
 export class PluginsMenu extends Menu implements ITreeItem {
     constructor(project: MavenProject) {
@@ -30,6 +31,7 @@ export class PluginsMenu extends Menu implements ITreeItem {
     }
 
     public async refresh(): Promise<void> {
-        await this._project.calculateEffectivePom(true);
+        this._project.effectivePom.upToDate = false;
+        mavenExplorerProvider.refresh(this);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,6 +150,12 @@ function registerPomFileWatcher(context: vscode.ExtensionContext): void {
         const project: MavenProject | undefined = mavenExplorerProvider.getMavenProject(e.fsPath);
         if (project) {
             await project.refresh();
+            if (Settings.Pomfile.autoUpdateEffectivePOM()) {
+                taskExecutor.execute(async () => {
+                    await project.effectivePom.update();
+                    mavenExplorerProvider.refresh(project)
+                });
+            }
         }
     }, null, context.subscriptions);
     watcher.onDidDelete((e: Uri) => mavenExplorerProvider.removeProject(e.fsPath), null, context.subscriptions);


### PR DESCRIPTION
See: #319 
To avoid performance deterioration, add a settings entry `maven.pomfile.autoUpdateEffectivePOM` which allows users to decide whether to auto-calculate effective-pom when pom.xml changes are detected.

Note: `Effective.upToDate` now serves as a flag indicating current cached effective is dirty or not.