### PR TITLE
Use embedded mvnw as fallback only when creating project

### DIFF
--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -7,7 +7,7 @@ import { QuickPickItem, Uri, window, workspace } from "vscode";
 import { instrumentOperationStep, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { OperationCanceledError } from "../Errors";
 import { getMavenLocalRepository, getPathToExtensionRoot } from "../utils/contextUtils";
-import { executeInTerminal, getEmbededMavenWrapper, getMaven } from "../utils/mavenUtils";
+import { executeInTerminal, getEmbeddedMavenWrapper, getMaven } from "../utils/mavenUtils";
 import { openDialogForFolder } from "../utils/uiUtils";
 import { Utils } from "../utils/Utils";
 import { Archetype } from "./Archetype";
@@ -50,7 +50,7 @@ export namespace ArchetypeModule {
         let cwd: string = targetFolder;
         if (!await getMaven()) {
             cmdArgs.push(`-DoutputDirectory="${targetFolder}"`);
-            mvnPath = getEmbededMavenWrapper();
+            mvnPath = getEmbeddedMavenWrapper();
             cwd = path.dirname(mvnPath);
         }
         await executeInTerminal({ mvnPath, command: cmdArgs.join(" "), pomfile: undefined, terminalName: "Maven archetype", cwd });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     context.subscriptions.push(mavenOutputChannel, mavenTerminal, taskExecutor);
     // register common goals
     ["clean", "validate", "compile", "test", "package", "verify", "install", "site", "deploy"].forEach((goal: string) => {
-        registerCommand(context, `maven.goal.${goal}`, async (node: MavenProject) => executeInTerminal(goal, node.pomPath));
+        registerCommand(context, `maven.goal.${goal}`, async (node: MavenProject) => executeInTerminal({ command: goal, pomfile: node.pomPath }));
     });
     registerCommand(context, "maven.explorer.refresh", async (item?: ITreeItem): Promise<void> => {
         if (item && item.refresh) {
@@ -101,7 +101,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     });
     registerCommand(context, "maven.favorites", async (item: MavenProject | undefined) => await runFavoriteCommandsHandler(item));
     registerCommand(context, "maven.goal.execute", async () => await Utils.executeMavenCommand());
-    registerCommand(context, "maven.plugin.execute", async (pluginGoal: PluginGoal) => await executeInTerminal(pluginGoal.name, pluginGoal.plugin.project.pomPath));
+    registerCommand(context, "maven.plugin.execute", async (pluginGoal: PluginGoal) => await executeInTerminal({ command: pluginGoal.name, pomfile: pluginGoal.plugin.project.pomPath }));
     registerCommand(context, "maven.view.flat", () => Settings.changeToFlatView());
     registerCommand(context, "maven.view.hierarchical", () => Settings.changeToHierarchicalView());
 

--- a/src/handlers/debugHandler.ts
+++ b/src/handlers/debugHandler.ts
@@ -26,10 +26,16 @@ async function debug(pomPath: string, command: string): Promise<void> {
         `-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=${freePort}` // MAVEN_DEBUG_OPTS
     ].filter(Boolean).join(" ");
     const sessionId: string = createUuid().substr(0, 6);
-    const debugTerimnal: vscode.Terminal = await executeInTerminal(command, pomPath, {
-        name: `mvnDebug ${sessionId}: ${command}`,
+    const debugTerimnal: vscode.Terminal | undefined = await executeInTerminal({
+        command,
+        pomfile: pomPath,
+        terminalName: `mvnDebug ${sessionId}: ${command}`,
         env: { MAVEN_OPTS: mavenOpts }
     });
+    if (!debugTerimnal) {
+        return;
+    }
+
     const debugConfig: vscode.DebugConfiguration = {
         type: "java",
         name: `Maven (Attach) - ${sessionId}`,

--- a/src/handlers/runFavoriteCommandsHandler.ts
+++ b/src/handlers/runFavoriteCommandsHandler.ts
@@ -51,5 +51,5 @@ export async function runFavoriteCommandsHandler(project: MavenProject | undefin
         return;
     }
 
-    await executeInTerminal(selectedCommand.command, selectedProject.pomPath);
+    await executeInTerminal({ command: selectedCommand.command, pomfile: selectedProject.pomPath });
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -189,7 +189,7 @@ export namespace Utils {
         const inputGoals: string | undefined = await window.showInputBox({ placeHolder: "e.g. clean package -DskipTests", ignoreFocusOut: true });
         const trimmedGoals: string | undefined = inputGoals ? inputGoals.trim() : undefined;
         if (trimmedGoals) {
-            await executeInTerminal(trimmedGoals, pomPath);
+            await executeInTerminal({ command: trimmedGoals, pomfile: pomPath });
         }
     }
 
@@ -209,7 +209,7 @@ export namespace Utils {
             { placeHolder: "Select from history ...", ignoreFocusOut: true }
         ).then(item => item ? item.value : undefined);
         if (selected) {
-            await executeInTerminal(selected.command, selected.pomPath);
+            await executeInTerminal({ command: selected.command, pomfile: selected.pomPath });
         }
     }
 

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as which from "which";
 import { mavenOutputChannel } from "../mavenOutputChannel";
-import { ITerminalOptions, mavenTerminal } from "../mavenTerminal";
+import { mavenTerminal } from "../mavenTerminal";
 import { Settings } from "../Settings";
 import { getPathToExtensionRoot, getPathToTempFolder, getPathToWorkspaceStorage } from "./contextUtils";
 import { updateLRUCommands } from "./historyUtils";
@@ -40,7 +40,12 @@ export async function pluginDescription(pluginId: string, pomPath: string): Prom
 
 async function executeInBackground(mvnArgs: string, pomfile?: string): Promise<any> {
     const workspaceFolder: vscode.WorkspaceFolder | undefined = pomfile ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pomfile)) : undefined;
-    const mvn: string = await getMaven(workspaceFolder);
+    const mvn: string | undefined = await getMaven(workspaceFolder);
+    if (mvn === undefined) {
+        await promptToSettingMavenExecutable();
+        return undefined;
+    }
+
     const command: string = wrappedWithQuotes(mvn);
     const cwd: string | undefined = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, mvn, "..") : undefined;
     const userArgs: string | undefined = Settings.Executable.options(pomfile);
@@ -80,25 +85,39 @@ async function executeInBackground(mvnArgs: string, pomfile?: string): Promise<a
     });
 }
 
-export async function executeInTerminal(command: string, pomfile?: string, options?: ITerminalOptions): Promise<vscode.Terminal> {
+export async function executeInTerminal(options: {
+    command: string;
+    mvnPath?: string;
+    pomfile?: string;
+    cwd?: string;
+    env?: { [key: string]: string };
+    terminalName?: string;
+}): Promise<vscode.Terminal | undefined> {
+    const {command, mvnPath, pomfile, cwd, env, terminalName} = options;
     const workspaceFolder: vscode.WorkspaceFolder | undefined = pomfile ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pomfile)) : undefined;
-    const mvnString: string = wrappedWithQuotes(await mavenTerminal.formattedPathForTerminal(await getMaven(workspaceFolder)));
+    const mvn: string | undefined = mvnPath ? mvnPath : await getMaven(workspaceFolder);
+    if (mvn === undefined) {
+        await promptToSettingMavenExecutable();
+        return undefined;
+    }
+
+    const mvnString: string = wrappedWithQuotes(await mavenTerminal.formattedPathForTerminal(mvn));
     const fullCommand: string = [
         mvnString,
         command.trim(),
         pomfile && `-f "${await mavenTerminal.formattedPathForTerminal(pomfile)}"`,
         Settings.Executable.options(pomfile)
     ].filter(Boolean).join(" ");
-    const name: string = workspaceFolder ? `Maven-${workspaceFolder.name}` : "Maven";
-    const terminal: vscode.Terminal = await mavenTerminal.runInTerminal(fullCommand, Object.assign({ name }, options));
+    const name: string = terminalName || (workspaceFolder ? `Maven-${workspaceFolder.name}` : "Maven");
+    const terminal: vscode.Terminal = await mavenTerminal.runInTerminal(fullCommand, {name, cwd, env});
     if (pomfile) {
         await updateLRUCommands(command, pomfile);
     }
     return terminal;
 }
 
-async function getMaven(workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
-    const workspaceFolderUri : vscode.Uri | undefined = workspaceFolder && workspaceFolder.uri;
+export async function getMaven(workspaceFolder?: vscode.WorkspaceFolder): Promise<string | undefined> {
+    const workspaceFolderUri: vscode.Uri | undefined = workspaceFolder && workspaceFolder.uri;
     const mvnPathFromSettings: string | undefined = Settings.Executable.path(workspaceFolderUri);
     if (mvnPathFromSettings) {
         return mvnPathFromSettings;
@@ -113,14 +132,18 @@ async function getMaven(workspaceFolder?: vscode.WorkspaceFolder): Promise<strin
     }
 }
 
+export function getEmbededMavenWrapper(): string {
+    return getPathToExtensionRoot("mvnw", "mvnw");
+}
+
 async function defaultMavenExecutable(): Promise<string> {
     return new Promise<string>((resolve) => {
         which("mvn", (_err, filepath) => {
             if (filepath) {
                 resolve("mvn");
             } else {
-                mavenOutputChannel.appendLine("Maven executable not found in PATH, use embeded mvnw as fallback.");
-                resolve(getPathToExtensionRoot("mvnw", "mvnw"));
+                mavenOutputChannel.appendLine("Maven executable not found in PATH.");
+                resolve(undefined);
             }
         });
     });
@@ -144,4 +167,12 @@ async function readFileIfExists(filepath: string): Promise<string | undefined> {
 function getTempTolder(identifier: string): string {
     const outputPath: string | undefined = getPathToWorkspaceStorage(md5(identifier));
     return outputPath ? outputPath : getPathToTempFolder(md5(identifier));
+}
+
+async function promptToSettingMavenExecutable(): Promise<void> {
+    const BUTTON_GOTO_SETTINGS: string = "Open Settings";
+    const choice: string | undefined = await vscode.window.showInformationMessage("Maven executable not found in PATH. Please specify maven.executable.path in Settings.", BUTTON_GOTO_SETTINGS);
+    if (choice === BUTTON_GOTO_SETTINGS) {
+        await vscode.commands.executeCommand("workbench.action.openSettings", "maven.executable.path");
+    }
 }

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -132,7 +132,7 @@ export async function getMaven(workspaceFolder?: vscode.WorkspaceFolder): Promis
     }
 }
 
-export function getEmbededMavenWrapper(): string {
+export function getEmbeddedMavenWrapper(): string {
     return getPathToExtensionRoot("mvnw", "mvnw");
 }
 


### PR DESCRIPTION
- refactor util `executeInTerminal`
- use embedded mvnw only when create project. 

This fixes #352 