### PR TITLE
set user error for maven.project.showDependencies

### DIFF
--- a/src/handlers/showDependenciesHandler.ts
+++ b/src/handlers/showDependenciesHandler.ts
@@ -34,7 +34,8 @@ async function getDependencyTree(pomPathOrMavenProject: string | MavenProject): 
         async (resolve, reject): Promise<void> => {
             p.report({ message: `Generating Dependency Tree: ${name}` });
             try {
-                resolve(rawDependencyTree(pomPath));
+                await rawDependencyTree(pomPath);
+                resolve();
                 return;
             } catch (error) {
                 setUserError(<Error>error);


### PR DESCRIPTION
Previously, errors are thrown directly from `rawDependencyTree(pomPath)`, without being set as user error. 
