### PR TITLE
Add small detail for path of executable

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -12,7 +12,7 @@ There are 2 types of command execution methods.
 
 * Install **Java**. Java Runtime is essential to run Maven commands. E.g. [AdoptOpenJDK](https://adoptopenjdk.net/), [Oracle OpenJDK](https://jdk.java.net/), etc.
 * **[Install Maven](https://maven.apache.org/install.html) / Maven Wrapper**. The extension actually leverages Maven executable file in your local machine. By default, it tries the following ones in order:
-  1. The absolute path specified in config `maven.executable.path` if it is not empty.
+  1. The absolute path specified in config `maven.executable.path` if it is not empty.  This should be the full path including `mvn`, e.g. `"maven.executable.path": "/opt/apache-maven-3.6.2/bin/mvn"` in your `settings.json` file.
   2. `mvnw` file under your workspace root folder. (If you prefer to bypass this one, you can change value of config `maven.executable.preferMavenWrapper` to `false`.)
   3. `mvn` in your system's `PATH`.
 


### PR DESCRIPTION
In specifying the "full path" for the executable, I had it set to just `/opt/apache-maven-3.6.2/bin` as per the requirement for `$PATH`.  Adding this extra detail would have saved me some time, so might be useful in the troubleshooting section.  Thanks.