### PR TITLE
find all projects at startup

### DIFF
--- a/src/explorer/mavenExplorerProvider.ts
+++ b/src/explorer/mavenExplorerProvider.ts
@@ -3,10 +3,10 @@
 
 import { TreeDataProvider } from "vscode";
 import * as vscode from "vscode";
+import { Utils } from "../utils/Utils";
 import { ITreeItem } from "./model/ITreeItem";
 import { MavenProject } from "./model/MavenProject";
 import { WorkspaceFolder } from "./model/WorkspaceFolder";
-import { Utils } from "../utils/Utils";
 
 class MavenExplorerProvider implements TreeDataProvider<ITreeItem> {
     public readonly onDidChangeTreeData: vscode.Event<ITreeItem>;
@@ -69,7 +69,7 @@ class MavenExplorerProvider implements TreeDataProvider<ITreeItem> {
         this._onDidChangeTreeData.fire(item);
     }
 
-    public async loadProjects(workspaceFolder?: vscode.WorkspaceFolder) : Promise<MavenProject[]>{
+    public async loadProjects(workspaceFolder?: vscode.WorkspaceFolder) : Promise<MavenProject[]> {
         const newProjects: MavenProject[] = [];
         const allProjects: MavenProject[] = [];
         const pomPaths: string[] = await Utils.getAllPomPaths(workspaceFolder);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,7 @@ export function registerCommand(context: vscode.ExtensionContext, commandName: s
 async function doActivate(_operationId: string, context: vscode.ExtensionContext): Promise<void> {
     pluginInfoProvider.initialize(context);
     // register tree view
+    await mavenExplorerProvider.loadProjects();
     context.subscriptions.push(vscode.window.createTreeView("mavenProjects", { treeDataProvider: mavenExplorerProvider, showCollapseAll: true }));
     // pom.xml listener to refresh tree view
     registerPomFileWatcher(context);

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -99,7 +99,15 @@ export namespace Utils {
         });
     }
 
-    export async function getAllPomPaths(workspaceFolder: WorkspaceFolder): Promise<string[]> {
+    export async function getAllPomPaths(workspaceFolder?: WorkspaceFolder): Promise<string[]> {
+        if (!workspaceFolder) {
+            if (workspace.workspaceFolders) {
+                const arrayOfPoms = await Promise.all(workspace.workspaceFolders.map(wf => getAllPomPaths(wf)))
+                return [].concat.apply([], ...arrayOfPoms);
+            } else {
+                return [];
+            }
+        }
         const exclusions: string[] = Settings.excludedFolders(workspaceFolder.uri);
         const pattern: string = Settings.Pomfile.globPattern();
         const pomFileUris: Uri[] = await workspace.findFiles(new RelativePattern(workspaceFolder, pattern), `{${exclusions.join(",")}}`);

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -102,7 +102,7 @@ export namespace Utils {
     export async function getAllPomPaths(workspaceFolder?: WorkspaceFolder): Promise<string[]> {
         if (!workspaceFolder) {
             if (workspace.workspaceFolders) {
-                const arrayOfPoms = await Promise.all(workspace.workspaceFolders.map(wf => getAllPomPaths(wf)))
+                const arrayOfPoms: string[][] = await Promise.all(workspace.workspaceFolders.map(getAllPomPaths));
                 return [].concat.apply([], ...arrayOfPoms);
             } else {
                 return [];


### PR DESCRIPTION
See #429 
* change `getAllPomPaths` to accept empty params, indicating finding pom files for all workspaceFolder.
* find all projects at startup after the extension is activated.