### PR TITLE
support to debug favorite commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -493,6 +493,11 @@
                   "type": "string",
                   "minLength": 1,
                   "description": "%configuration.maven.terminal.favorites.command%"
+                },
+                "debug": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "%configuration.maven.terminal.favorites.debug%"
                 }
               }
             },

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,5 +28,6 @@
     "configuration.maven.view": "Specifies the way of viewing Maven projects.",
     "configuration.maven.terminal.favorites": "Specify pre-defined favorite commands to execute.",
     "configuration.maven.terminal.favorites.alias": "A short name for the command.",
-    "configuration.maven.terminal.favorites.command": "Content of the favorite command."
+    "configuration.maven.terminal.favorites.command": "Content of the favorite command.",
+    "configuration.maven.terminal.favorites.debug": "Whether to execute in debug mode."
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -28,5 +28,6 @@
     "configuration.maven.view": "指定 Maven 项目的视图方式。",
     "configuration.maven.terminal.favorites": "指定要执行的偏好命令。",
     "configuration.maven.terminal.favorites.alias": "命令的简称。",
-    "configuration.maven.terminal.favorites.command": "命令的内容。"
+    "configuration.maven.terminal.favorites.command": "命令的内容。",
+    "configuration.maven.terminal.favorites.debug": "是否以调试模式运行。"
 }

--- a/src/handlers/debugHandler.ts
+++ b/src/handlers/debugHandler.ts
@@ -9,14 +9,17 @@ import { Settings } from "../Settings";
 import { executeInTerminal } from "../utils/mavenUtils";
 
 export async function debugHandler(goal: PluginGoal): Promise<void> {
+    const pomfile: string = goal.plugin.project.pomPath;
+    const command: string = goal.name;
+    await debugCommand({ command, pomfile });
+}
+
+export async function debugCommand(options: { pomfile: string; command: string }) {
     if (!isJavaDebuggerEnabled()) {
         await guideToInstallJavaDebugger();
         return;
     }
-
-    const pomPath: string = goal.plugin.project.pomPath;
-    const command: string = goal.name;
-    await debug(pomPath, command);
+    await debug(options.pomfile, options.command);
 }
 
 async function debug(pomPath: string, command: string): Promise<void> {

--- a/src/handlers/debugHandler.ts
+++ b/src/handlers/debugHandler.ts
@@ -14,7 +14,7 @@ export async function debugHandler(goal: PluginGoal): Promise<void> {
     await debugCommand({ command, pomfile });
 }
 
-export async function debugCommand(options: { pomfile: string; command: string }) {
+export async function debugCommand(options: { pomfile: string; command: string }): Promise<void> {
     if (!isJavaDebuggerEnabled()) {
         await guideToInstallJavaDebugger();
         return;

--- a/src/handlers/runFavoriteCommandsHandler.ts
+++ b/src/handlers/runFavoriteCommandsHandler.ts
@@ -7,8 +7,9 @@ import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
 import { MavenProject } from "../explorer/model/MavenProject";
 import { Settings } from "../Settings";
 import { executeInTerminal } from "../utils/mavenUtils";
+import { debugCommand } from "./debugHandler";
 
-type FavoriteCommand = { command: string, alias: string };
+type FavoriteCommand = { command: string, alias: string, debug?: boolean };
 export async function runFavoriteCommandsHandler(project: MavenProject | undefined): Promise<void> {
     let selectedProject: MavenProject | undefined = project;
     if (!selectedProject) {
@@ -51,5 +52,10 @@ export async function runFavoriteCommandsHandler(project: MavenProject | undefin
         return;
     }
 
-    await executeInTerminal({ command: selectedCommand.command, pomfile: selectedProject.pomPath });
+    const config: any = { command: selectedCommand.command, pomfile: selectedProject.pomPath };
+    if (selectedCommand.debug) {
+        await debugCommand(config);
+    } else {
+        await executeInTerminal(config);
+    }
 }


### PR DESCRIPTION
This somehow resolves  #444 

It adds `debug: boolean` in schema of favorite command, and run/debug depending on the flag.
