### PR TITLE
Open cmd when running inside PowerShell

### DIFF
--- a/src/mavenTerminal.ts
+++ b/src/mavenTerminal.ts
@@ -79,7 +79,7 @@ function getCommand(cmd: string): string {
     if (process.platform === "win32") {
         switch (currentWindowsShell()) {
             case WindowsShellType.POWERSHELL:
-                return `& ${cmd}`; // PowerShell
+                return `cmd /c ${cmd}`; // PowerShell
             default:
                 return cmd; // others, try using common one.
         }


### PR DESCRIPTION
As of today, when VSCode default's terminal is PowerShell, running a maven command opens a new cmd window, and when the process is finished, this window is closed and we can't see what happened.

With this change, we force PowerShell to run the command in it's own window.