### PR TITLE
expand tilde as home dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,6 +1881,11 @@
                 }
             }
         },
+        "expand-home-dir": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
+            "integrity": "sha1-ct6KBIbMKKO71wRjU5iCW1tign0="
+        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -546,6 +546,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "expand-home-dir": "0.0.3",
     "fast-glob": "^2.2.7",
     "fs-extra": "^4.0.3",
     "get-port": "^4.2.0",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module "xml-zero-lexer";
+declare module "expand-home-dir";

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as child_process from "child_process";
+import * as expandHome from "expand-home-dir";
 import * as fse from "fs-extra";
 import * as md5 from "md5";
 import * as path from "path";
@@ -114,7 +115,8 @@ export async function executeInTerminal(options: {
 export async function getMaven(pomPath?: string): Promise<string | undefined> {
     const mvnPathFromSettings: string | undefined = Settings.Executable.path(pomPath);
     if (mvnPathFromSettings) {
-        return mvnPathFromSettings;
+        // expand tilde to deal with ~/path-to-mvn
+        return expandHome(mvnPathFromSettings);
     }
 
     const preferMavenWrapper: boolean = Settings.Executable.preferMavenWrapper(pomPath);

--- a/src/xml-zero-lexer.d.ts
+++ b/src/xml-zero-lexer.d.ts
@@ -1,1 +1,0 @@
-declare module "xml-zero-lexer";


### PR DESCRIPTION
 On Mac, the Maven Projects command adds extra double-quote around the mvn path. Example: the clean command try to execute `~/Documents/workspace/tool/apache-maven-3.6.1/bin/mvn clean`. Bash return error, No such file or directory. Change `~/Documents/workspace/tool/apache-maven-3.6.1/bin/mvn clean` to `~/Documents/workspace/tool/apache-maven-3.6.1/bin/mvn clean` and solve the problem.