### PR TITLE
refine scope of setting maven.executable.* 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -598,7 +598,7 @@
                 },
                 "util": {
                     "version": "0.10.3",
-                    "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
                     "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
                     "dev": true,
                     "requires": {
@@ -3676,7 +3676,7 @@
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -417,13 +417,13 @@
             "type": "string",
             "default": "",
             "description": "%configuration.maven.executable.path%",
-            "scope": "resource"
+            "scope": "machine"
           },
           "maven.executable.options": {
             "type": "string",
             "default": "",
             "description": "%configuration.maven.executable.options%",
-            "scope": "resource"
+            "scope": "machine-overridable"
           },
           "maven.terminal.useJavaHome": {
             "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -411,19 +411,19 @@
             "type": "boolean",
             "default": "true",
             "description": "%configuration.maven.executable.preferMavenWrapper%",
-            "scope": "machine"
+            "scope": "resource"
           },
           "maven.executable.path": {
             "type": "string",
             "default": "",
             "description": "%configuration.maven.executable.path%",
-            "scope": "machine"
+            "scope": "resource"
           },
           "maven.executable.options": {
             "type": "string",
             "default": "",
             "description": "%configuration.maven.executable.options%",
-            "scope": "machine"
+            "scope": "resource"
           },
           "maven.terminal.useJavaHome": {
             "type": "boolean",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { Uri, workspace } from "vscode";
 
 export namespace Settings {
     export function excludedFolders(resource: Uri): string[] {
@@ -25,23 +25,6 @@ export namespace Settings {
         workspace.getConfiguration().update("maven.executable.path", mvnPath, true);
     }
 
-    export function setPreferWrapper(value: boolean): void {
-        workspace.getConfiguration().update("maven.executable.preferMavenWrapper", value, true);
-    }
-
-    export function isPreferenceOverridden(section: string): boolean {
-        const config: WorkspaceConfiguration = workspace.getConfiguration();
-        const inspect = config.inspect(section);
-        if (inspect === undefined) {
-            return false;
-        }
-        return inspect.workspaceFolderValue !== undefined ||
-            inspect.workspaceFolderLanguageValue !== undefined ||
-            inspect.workspaceValue !== undefined ||
-            inspect.workspaceLanguageValue !== undefined ||
-            inspect.globalValue !== undefined ||
-            inspect.globalLanguageValue !== undefined;
-    }
     export namespace External {
         export function javaHome(): string | undefined {
             return workspace.getConfiguration("java").get<string>("home");
@@ -75,8 +58,8 @@ export namespace Settings {
         export function options(resourceOrFilepath?: Uri | string): string | undefined {
             return _getMavenSection("executable.options", resourceOrFilepath);
         }
-        export function preferMavenWrapper(resourceOrFilepath?: Uri | string): boolean | undefined {
-            return _getMavenSection("executable.preferMavenWrapper", resourceOrFilepath);
+        export function preferMavenWrapper(resourceOrFilepath?: Uri | string): boolean {
+            return !!_getMavenSection("executable.preferMavenWrapper", resourceOrFilepath);
         }
     }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -37,7 +37,7 @@ export namespace Settings {
 
     export namespace Terminal {
         export function useJavaHome(): boolean {
-            return !!_getMavenSection("terminal.useJavaHome");
+            return !!_getMavenSection<boolean>("terminal.useJavaHome");
         }
 
         export function customEnv(resourceOrFilepath?: Uri | string): {
@@ -59,7 +59,7 @@ export namespace Settings {
             return _getMavenSection("executable.options", resourceOrFilepath);
         }
         export function preferMavenWrapper(resourceOrFilepath?: Uri | string): boolean {
-            return !!_getMavenSection("executable.preferMavenWrapper", resourceOrFilepath);
+            return !!_getMavenSection<boolean>("executable.preferMavenWrapper", resourceOrFilepath);
         }
     }
 

--- a/tslint.json
+++ b/tslint.json
@@ -185,6 +185,7 @@
             "call-signature",
             "parameter",
             "property-declaration",
+            "variable-declaration",
             "member-variable-declaration"
         ],
         "underscore-consistent-invocation": true,


### PR DESCRIPTION
**maven.executable.path** -> remain `machine` scope, for security concern.
**maven.executable.options** -> change to `machine-overridable`, to fix #524 
**maven.executable.preferMavenWrapper** -> revert to `resource` scope, to mitigate #523 
