### PR TITLE
Make optional the File Explorer context menu entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
       "explorer/context": [
         {
           "command": "maven.archetype.generate",
+          "when": "config.maven.showInExplorerContextMenu && explorerResourceIsFolder",
           "group": "maven@3"
         },
         {
@@ -522,6 +523,12 @@
             "default": "flat",
             "scope": "window",
             "description": "%configuration.maven.view%"
+          },
+          "maven.showInExplorerContextMenu": {
+            "type": "boolean",
+            "default": "true",
+            "description": "%configuration.maven.showInExplorerContextMenu%",
+            "scope": "resource"
           },
           "maven.pomfile.globPattern": {
             "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -27,6 +27,7 @@
     "configuration.maven.terminal.customEnv.environmentVariable": "Name of the environment variable to set.",
     "configuration.maven.terminal.customEnv.value": "Value of the environment variable to set.",
     "configuration.maven.view": "Specifies the way of viewing Maven projects.",
+    "configuration.maven.showInExplorerContextMenu": "If this value is true, add a command to create Maven Projects in the Explorer context menu for folders.",
     "configuration.maven.terminal.favorites": "Specify pre-defined favorite commands to execute.",
     "configuration.maven.terminal.favorites.alias": "A short name for the command.",
     "configuration.maven.terminal.favorites.command": "Content of the favorite command.",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -9,6 +9,10 @@ export namespace Settings {
         return ret !== undefined ? ret : [];
     }
 
+    export function showInExplorerContextMenu(): boolean {
+        return !!_getMavenSection<boolean>("maven.showInExplorerContextMenu");
+    }
+
     export function viewType(): string | undefined {
         return _getMavenSection("view");
     }


### PR DESCRIPTION
The globally enabled entry in the Explorer right-click menu is a teensy bit intrusive for users who are not working with Java/Maven exclusively or nearly so. This quick patch introduces an option to enable or disable the entry, and disables it by default.

A few notes:
  - Disabling the entry by default is bound to surprise a few users at the next update. Even so, I reckon that it should be the preferred behavior.
  - The informal "Generate project from maven archetypes" test from `TestPlan.md` is somewhat overloaded now that it also includes a procedure to test the menu setting. I'd be happy to split the test in two, one for the setting and one for project generation proper.
  - Line endings seemed to be inconsistent across files and, within `TestPlan.md`, across lines. I have tried not to alter them.
  - I am unable to provide a Chinese description for the setting. Feel free to provide me with one, open a PR against my branch, or make edits directly.

Also note that there is a similar issue with the "Maven" section for the Explorer, which is introduced by this extension and active by default. It is not addressed here because, while intrusive, it can be disabled with ease—unlike the context menu entry.