### PR TITLE
do not provide navigation link if version is unresolved

### DIFF
--- a/src/definition/definitionProvider.ts
+++ b/src/definition/definitionProvider.ts
@@ -32,7 +32,7 @@ class DefinitionProvider implements vscode.DefinitionProvider {
         if (groupIdHint && artifactIdHint) {
           const mavenProject: MavenProject | undefined = mavenExplorerProvider.getMavenProject(document.uri.fsPath);
           const version: string | undefined = mavenProject?.getDependencyVersion(groupIdHint, artifactIdHint) || versionHint;
-          if (version) {
+          if (version && !version.match(/^\$\{.*\}$/)) { // skip for unresolved properties, e.g. ${azure.version}
             const pomPath: string = localPomPath(groupIdHint, artifactIdHint, version);
             return new vscode.Location(vscode.Uri.file(pomPath), new vscode.Position(0, 0));
           }


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-maven/issues/558#issuecomment-755825830

if effective pom is not correctly calculated, `<version>${azure.version}</version>` cannot be resolved, thus the target navigation link is wrong.