### PR TITLE
exclude archetype-resources folder for searching pom files

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To speed up the searching of Maven projects, you can exclude folders in settings
 
 ```json
 {
-    "maven.projects.excludedFolders": [
+    "maven.excludedFolders": [
         "**/.*",                // exclude hidden folders
         "**/node_modules",      // exclude node modules to speed up
         "**/target"             // exclude duplicated pom file in target folder
@@ -182,7 +182,7 @@ Now right-click on an project item, and then click `Favorite ...`. The option `f
 
 | Name | Description | Default Value |
 |---|---|---|
-| `maven.excludedFolders` | Specifies file path pattern of folders to exclude while searching for Maven projects. | `[ "**/.*", "**/node_modules", "**/target", "**/bin" ]` |
+| `maven.excludedFolders` | Specifies file path pattern of folders to exclude while searching for Maven projects. | `[ "**/.*", "**/node_modules", "**/target", "**/bin", "**/archetype-resources" ]` |
 | `maven.executable.preferMavenWrapper` | Specifies whether you prefer to use Maven wrapper. If true, it tries using 'mvnw' by walking up the parent folders. If false, or 'mvnw' is not found, it tries 'mvn' in PATH instead. | `true` |
 | `maven.executable.path` | Specifies absolute path of your 'mvn' executable. When this value is empty, it tries using 'mvn' or 'mvnw' according to the value of 'maven.executable.preferMavenWrapper'. E.g. `/usr/local/apache-maven-3.6.0/bin/mvn` | ` ` |
 | `maven.executable.options` | Specifies default options for all mvn commands. E.g. `-o -DskipTests` | ` ` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,8 +740,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },
@@ -1546,9 +1545,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
-      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
+      "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ=="
     },
     "diff": {
       "version": "3.5.0",
@@ -4808,8 +4807,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },
@@ -6013,9 +6011,9 @@
       }
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.8.0.tgz",
-      "integrity": "sha512-z+PAc7QAMeTZU0Kq0oBn7DVinJDLtyK5DNZV0dSkclXPYlIVAalE5iEWBChXgANxaMWCyJQqCEI60zlZ7r7C/A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.9.0.tgz",
+      "integrity": "sha512-QQvCn40hryS1U0Vob/fxqDX+kc7oYn+viiYpq0QOMp7q6aNaFFmjL9Wv5QfBIC/h2Jb083LFF0Xz38hhX8nCVQ==",
       "requires": {
         "uuid": "^3.4.0",
         "vscode-extension-telemetry": "^0.1.6"

--- a/package.json
+++ b/package.json
@@ -435,7 +435,8 @@
               "**/.*",
               "**/node_modules",
               "**/target",
-              "**/bin"
+              "**/bin",
+              "**/archetype-resources"
             ],
             "description": "%configuration.maven.excludedFolders%",
             "scope": "resource"
@@ -593,7 +594,7 @@
     "lodash": "^4.17.19",
     "md5": "^2.2.1",
     "minimatch": "^3.0.4",
-    "vscode-extension-telemetry-wrapper": "^0.8.0",
+    "vscode-extension-telemetry-wrapper": "^0.9.0",
     "vscode-languageclient": "^6.1.3",
     "vscode-languageserver-protocol": "^3.15.3",
     "which": "^1.3.1",


### PR DESCRIPTION
By default exclude folder "**/archetype-resources". 

To fix #580 