### PR TITLE
only load custom envs in terminal commands

### DIFF
--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -52,7 +52,7 @@ async function executeInBackground(mvnArgs: string, pomfile?: string): Promise<a
     }
     const spawnOptions: child_process.SpawnOptions = {
         cwd,
-        env: Object.assign({}, process.env, Settings.getEnvironment(pomfile)),
+        env: process.env,
         shell: true
     };
     return new Promise<{}>((resolve: (value: any) => void, reject: (e: Error) => void): void => {


### PR DESCRIPTION
> maven.terminal.customEnv: 
> Specifies an array of environment variable names and values. These environment variable values will be added to the **terminal session** before Maven is first executed.",

As described, this setting should only affect commands sent to terminal. This PR removes custom env from background commands.