### PR TITLE
cache effective pom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4618,7 +4618,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "1.0.0",


### PR DESCRIPTION
ref: #579 

cached pom is saved into workspace storage. Together there will be a file `<hash>.mtime` recording last modified time of original `pom.xml` file, indicating whether the cache is valid. 