### PR TITLE
load cache of epom if exists on startup

### DIFF
--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -28,15 +28,14 @@ export class MavenProject implements ITreeItem {
     constructor(pomPath: string) {
         this.pomPath = pomPath;
         this.ePomProvider = new EffectivePomProvider(pomPath);
-        if (Settings.Pomfile.prefetchEffectivePom()) {
-            taskExecutor.execute(async () => {
-                try {
-                    await this.getEffectivePom();
-                } catch (error) {
-                    // ignore
-                }
-            });
-        }
+        const options: any = Settings.Pomfile.prefetchEffectivePom() ? undefined : { cacheOnly: true };
+        taskExecutor.execute(async () => {
+            try {
+                await this.getEffectivePom(options);
+            } catch (error) {
+                // ignore
+            }
+        });
     }
 
     public get name(): string {
@@ -127,13 +126,14 @@ export class MavenProject implements ITreeItem {
         await this.ePomProvider.calculateEffectivePom();
     }
 
-    public async getEffectivePom(): Promise<IEffectivePom> {
+    public async getEffectivePom(options?: { cacheOnly?: boolean }): Promise<IEffectivePom> {
         let res: IEffectivePom = { pomPath: this.pomPath };
         try {
-            res = await this.ePomProvider.getEffectivePom();
+            res = await this.ePomProvider.getEffectivePom(options);
             this._ePom = res.ePom;
         } catch (error) {
             console.error(error);
+            throw new Error("Failed to calculate Effective POM. Please check output window 'Maven for Java' for more details.");
         }
         return res;
     }


### PR DESCRIPTION
setting `prefetchEffectivePom` is false by default. So before user explicitly calculate effective pom, even though there's cache, it's not exploited. 

Now first read data from cache (if exists), as it's a fast operation. 