### PR TITLE
use TreeItem.description to provide show identifier

### DIFF
--- a/src/explorer/model/MavenPlugin.ts
+++ b/src/explorer/model/MavenPlugin.ts
@@ -33,9 +33,12 @@ export class MavenPlugin implements ITreeItem {
     }
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
-        const label: string = this.prefix ? `${this.prefix} (${this.pluginId})` : this.pluginId;
+        const label: string = this.prefix || this.pluginId;
         const treeItem: vscode.TreeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Collapsed);
         treeItem.iconPath = new vscode.ThemeIcon("symbol-property");
+        if (this.prefix) {
+            treeItem.description = this.pluginId;
+        }
         return treeItem;
     }
 

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -40,11 +40,19 @@ export class MavenProject implements ITreeItem {
 
     public get name(): string {
         // use <name> if provided, fallback to <artifactId>
-        return this._pom?.project?.name?.[0] || this._pom?.project?.artifactId?.[0];
+        return this._pom?.project?.name?.[0] ?? this._pom?.project?.artifactId?.[0];
+    }
+
+    public get groupId(): string {
+        return this._pom?.project?.groupId?.[0] ?? this.parent?.groupId;
+    }
+
+    public get artifactId(): string {
+        return this._pom?.project?.artifactId?.[0];
     }
 
     public get id(): string {
-        return `${this._pom?.project?.groupId?.[0]}:${this._pom?.project?.artifactId?.[0]}`;
+        return `${this.groupId}:${this.artifactId}`;
     }
 
     public get packaging(): string {
@@ -102,7 +110,7 @@ export class MavenProject implements ITreeItem {
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
         await this.parsePom();
-        const label: string = this.name ? this.name : "[Corrupted]";
+        const label: string = this.name ?? this.artifactId ?? "[Corrupted]";
         const iconFile: string = this.packaging === "pom" ? "root.svg" : "project.svg";
         const treeItem: vscode.TreeItem = new vscode.TreeItem(label);
         treeItem.iconPath = {

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -40,7 +40,12 @@ export class MavenProject implements ITreeItem {
     }
 
     public get name(): string {
-        return _.get(this._pom, "project.artifactId[0]");
+        // use <name> if provided, fallback to <artifactId>
+        return this._pom?.project?.name?.[0] || this._pom?.project?.artifactId?.[0];
+    }
+
+    public get id(): string {
+        return `${this._pom?.project?.groupId?.[0]}:${this._pom?.project?.artifactId?.[0]}`;
     }
 
     public get packaging(): string {
@@ -106,6 +111,7 @@ export class MavenProject implements ITreeItem {
             dark: getPathToExtensionRoot("resources", "icons", "dark", iconFile)
         };
         treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+        treeItem.description = this.id;
         return treeItem;
     }
 


### PR DESCRIPTION
Related issue: #590 

Solution:
- Maven items
  - label: show "name" if provided, "artifactId" as fallback.
  - description: always show groupId : artifactId. (version is omitted as I don't think it's that important in distinguishing)
- Plugin items
  - before resolving it to get detailed info (e.g. prefix), show qualified id, aka. groupId:artifactId:version
  - show "prefix" if resolved, and put qualified id in description


After this PR:
![image](https://user-images.githubusercontent.com/2351748/112276422-b053ff80-8cbb-11eb-8c9c-18ddcaa213cc.png)
