### PR TITLE
Execute and return when select "Custom ..." or "Favorites ..."

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -270,10 +270,10 @@ export namespace Utils {
             switch (selectedCommand) {
                 case LABEL_CUSTOM:
                     await commands.executeCommand("maven.goal.custom", selectedProject);
-                    break;
+                    return;
                 case LABEL_FAVORITES:
                     await commands.executeCommand("maven.favorites", selectedProject);
-                    break;
+                    return;
                 default:
                     break;
             }


### PR DESCRIPTION
A error message here:
Command "maven.goal.execute" fails. command 'maven.goal.Favorites ...' not found
![image](https://user-images.githubusercontent.com/22905765/117648201-8352a200-b1c0-11eb-98cc-c180dbea28f5.png)

Steps to reproduce the behavior:
1. Ctrl+Shift+P (workbench.action.showCommands)
2. Select Maven: Execute Commands
3. Select a Maven project if necessary
4. Select "Favorites ... "
5. Select a favorite command

 - OS: Windows 10
 - VS Code version: 1.56.0
 - Extension version 0.30.1