### PR TITLE
implement inline command for dependency: Jump to definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "onCommand:maven.plugin.execute",
     "onCommand:maven.project.addDependency",
     "onCommand:maven.project.excludeDependency",
+    "onCommand:maven.project.jumpToDefinition",
     "onView:mavenProjects"
   ],
   "main": "./dist/extension",
@@ -205,6 +206,12 @@
         "category": "Maven"
       },
       {
+        "command": "maven.project.jumpToDefinition",
+        "title": "%contributes.commands.maven.project.jumpToDefinition%",
+        "category": "Maven",
+        "icon": "$(go-to-file)"
+      },
+      {
         "command": "maven.favorites",
         "title": "%contributes.commands.maven.favorites%",
         "category": "Maven"
@@ -304,6 +311,10 @@
         },
         {
           "command": "maven.project.excludeDependency",
+          "when": "never"
+        },
+        {
+          "command": "maven.project.jumpToDefinition",
           "when": "never"
         },
         {
@@ -432,6 +443,11 @@
           "command": "maven.project.excludeDependency",
           "when": "view == mavenProjects && viewItem == Dependency",
           "group": "0-dependency@0"
+        },
+        {
+          "command": "maven.project.jumpToDefinition",
+          "when": "view == mavenProjects && viewItem == Dependency",
+          "group": "inline"
         },
         {
           "command": "maven.project.openPom",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "onCommand:maven.plugin.execute",
     "onCommand:maven.project.addDependency",
     "onCommand:maven.project.excludeDependency",
-    "onCommand:maven.project.jumpToDefinition",
     "onView:mavenProjects"
   ],
   "main": "./dist/extension",
@@ -206,8 +205,8 @@
         "category": "Maven"
       },
       {
-        "command": "maven.project.jumpToDefinition",
-        "title": "%contributes.commands.maven.project.jumpToDefinition%",
+        "command": "maven.project.goToDefinition",
+        "title": "%contributes.commands.maven.project.goToDefinition%",
         "category": "Maven",
         "icon": "$(go-to-file)"
       },
@@ -314,7 +313,7 @@
           "when": "never"
         },
         {
-          "command": "maven.project.jumpToDefinition",
+          "command": "maven.project.goToDefinition",
           "when": "never"
         },
         {
@@ -445,7 +444,7 @@
           "group": "0-dependency@0"
         },
         {
-          "command": "maven.project.jumpToDefinition",
+          "command": "maven.project.goToDefinition",
           "when": "view == mavenProjects && viewItem == Dependency",
           "group": "inline"
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
     "contributes.commands.maven.project.addDependency": "Add a dependency...",
     "contributes.commands.maven.project.showDependencies": "Show dependencies",
     "contributes.commands.maven.project.excludeDependency": "Exclude dependency",
+    "contributes.commands.maven.project.jumpToDefinition": "Jump to Definition",
     "contributes.views.explorer.mavenProjects": "Maven",
     "contributes.viewsWelcome.mavenProjects.untrustedWorkspaces": "Advanced features (e.g. executing lifecycle phases and plugin goals) are disabled in Restricted Mode for security concern.\nPOM editing assistance (e.g. [add a dependency](command:maven.project.addDependency)) is still available.\nLearn more about [Workspace Trust](https://aka.ms/vscode-workspace-trust).\n[Manage Workspace Trust](command:workbench.action.manageTrust)",
     "configuration.maven.excludedFolders": "Specifies file path pattern of folders to exclude while searching for Maven projects.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,7 +16,7 @@
     "contributes.commands.maven.project.addDependency": "Add a dependency...",
     "contributes.commands.maven.project.showDependencies": "Show dependencies",
     "contributes.commands.maven.project.excludeDependency": "Exclude dependency",
-    "contributes.commands.maven.project.jumpToDefinition": "Jump to Definition",
+    "contributes.commands.maven.project.goToDefinition": "Go to Definition",
     "contributes.views.explorer.mavenProjects": "Maven",
     "contributes.viewsWelcome.mavenProjects.untrustedWorkspaces": "Advanced features (e.g. executing lifecycle phases and plugin goals) are disabled in Restricted Mode for security concern.\nPOM editing assistance (e.g. [add a dependency](command:maven.project.addDependency)) is still available.\nLearn more about [Workspace Trust](https://aka.ms/vscode-workspace-trust).\n[Manage Workspace Trust](command:workbench.action.manageTrust)",
     "configuration.maven.excludedFolders": "Specifies file path pattern of folders to exclude while searching for Maven projects.",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -15,7 +15,7 @@
     "contributes.commands.maven.view.flat": "切换到扁平视图",
     "contributes.commands.maven.project.addDependency": "添加依赖…",
     "contributes.commands.maven.project.showDependencies": "显示所有依赖",
-    "contributes.commands.maven.project.jumpToDefinition": "打开定义位置",
+    "contributes.commands.maven.project.goToDefinition": "转到定义",
     "contributes.commands.maven.project.excludeDependency": "删除依赖",
     "contributes.views.explorer.mavenProjects": "Maven",
     "configuration.maven.excludedFolders": "指定搜索 Maven 项目时要排除的文件夹。",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -15,6 +15,7 @@
     "contributes.commands.maven.view.flat": "切换到扁平视图",
     "contributes.commands.maven.project.addDependency": "添加依赖…",
     "contributes.commands.maven.project.showDependencies": "显示所有依赖",
+    "contributes.commands.maven.project.jumpToDefinition": "打开定义位置",
     "contributes.commands.maven.project.excludeDependency": "删除依赖",
     "contributes.views.explorer.mavenProjects": "Maven",
     "configuration.maven.excludedFolders": "指定搜索 Maven 项目时要排除的文件夹。",

--- a/src/definition/definitionProvider.ts
+++ b/src/definition/definitionProvider.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT license.
 
 import * as _ from "lodash";
-import * as path from "path";
 import * as vscode from "vscode";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
 import { MavenProject } from "../explorer/model/MavenProject";
-import { getMavenLocalRepository } from "../utils/contextUtils";
+import { localPomPath } from "../utils/contextUtils";
 import { ElementNode, getCurrentNode, XmlTagName } from "../utils/lexerUtils";
 
 class DefinitionProvider implements vscode.DefinitionProvider {
@@ -47,10 +46,6 @@ class DefinitionProvider implements vscode.DefinitionProvider {
         return undefined;
     }
   }
-}
-
-function localPomPath(gid: string, aid: string, version: string): string {
-  return path.join(getMavenLocalRepository(), ...gid.split("."), aid, version, `${aid}-${version}.pom`);
 }
 
 export const definitionProvider: DefinitionProvider = new DefinitionProvider();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { pluginInfoProvider } from "./explorer/pluginInfoProvider";
 import { addDependencyHandler } from "./handlers/addDependencyHandler";
 import { debugHandler } from "./handlers/debugHandler";
 import { excludeDependencyHandler } from "./handlers/excludeDependencyHandler";
+import { jumpToDefinitionHandler } from "./handlers/jumpToDefinitionHandler";
 import { runFavoriteCommandsHandler } from "./handlers/runFavoriteCommandsHandler";
 import { showDependenciesHandler } from "./handlers/showDependenciesHandler";
 import { hoverProvider } from "./hover/hoverProvider";
@@ -114,6 +115,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     registerCommand(context, "maven.project.addDependency", addDependencyHandler);
     registerCommand(context, "maven.project.showDependencies", showDependenciesHandler);
     registerCommand(context, "maven.project.excludeDependency", excludeDependencyHandler);
+    registerCommand(context, "maven.project.jumpToDefinition", jumpToDefinitionHandler);
 
     // debug
     registerCommand(context, "maven.plugin.debug", debugHandler);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     registerCommand(context, "maven.project.addDependency", addDependencyHandler);
     registerCommand(context, "maven.project.showDependencies", showDependenciesHandler);
     registerCommand(context, "maven.project.excludeDependency", excludeDependencyHandler);
-    registerCommand(context, "maven.project.jumpToDefinition", jumpToDefinitionHandler);
+    registerCommand(context, "maven.project.goToDefinition", jumpToDefinitionHandler);
 
     // debug
     registerCommand(context, "maven.plugin.debug", debugHandler);

--- a/src/handlers/jumpToDefinitionHandler.ts
+++ b/src/handlers/jumpToDefinitionHandler.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as fse from "fs-extra";
+import * as path from "path";
+import * as vscode from "vscode";
+import { Dependency } from "../explorer/model/Dependency";
+import { getMavenLocalRepository } from "../utils/contextUtils";
+import { UserError } from "../utils/errorUtils";
+import { ElementNode, getNodesByTag, XmlTagName } from "../utils/lexerUtils";
+
+export async function jumpToDefinitionHandler(node?: Dependency): Promise<void> {
+    if (node === undefined) {
+        throw new Error("Only Dependency can jump to definition.");
+    }
+
+    let selectedPath: string;
+    if (node.parent === undefined) {
+        selectedPath = node.projectPomPath;
+    } else {
+        const parent: Dependency = <Dependency> node.parent;
+        selectedPath = localPomPath(parent.groupId, parent.artifactId, parent.version);
+    }
+    await jumpToDefinition(selectedPath, node.artifactId);
+}
+
+async function jumpToDefinition(pomPath: string, aid: string): Promise<void> {
+    const contentBuf: Buffer = await fse.readFile(pomPath);
+    const projectNodes: ElementNode[] = getNodesByTag(contentBuf.toString(), XmlTagName.Project);
+    if (projectNodes === undefined || projectNodes.length !== 1) {
+        throw new UserError("Only support POM file with single <project> node.");
+    }
+
+    const projectNode: ElementNode = projectNodes[0];
+    const dependenciesNode: ElementNode | undefined = projectNode.children?.find(node => node.tag === XmlTagName.Dependencies);
+    const dependencyNode: ElementNode | undefined = dependenciesNode?.children && dependenciesNode?.children.find(node =>
+        node.children && node.children[1].tag === XmlTagName.ArtifactId && node.children[1].text === aid
+    );
+    const artifactNode: ElementNode | undefined = dependencyNode?.children?.find(node => node.tag === XmlTagName.ArtifactId);
+    if (artifactNode !== undefined) {
+        await locateInFile(pomPath, artifactNode);
+    } else {
+        throw new Error("Open the wrong pom file and can not find where the dependency has been imported.");
+    }
+}
+
+async function locateInFile(pomPath: string, targetNode: ElementNode): Promise<void> {
+    if (targetNode.contentStart === undefined || targetNode.contentEnd === undefined) {
+        throw new UserError("Invalid target XML node to locate.");
+    }
+    const currentDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(pomPath);
+    const textEditor: vscode.TextEditor = await vscode.window.showTextDocument(currentDocument, {preview: false});
+    const start = currentDocument.positionAt(targetNode.contentStart);
+    textEditor.selection = new vscode.Selection(start, start);
+    textEditor.revealRange(new vscode.Range(start, start), vscode.TextEditorRevealType.InCenter);
+}
+
+function localPomPath(gid: string, aid: string, version: string): string {
+    return path.join(getMavenLocalRepository(), ...gid.split("."), aid, version, `${aid}-${version}.pom`);
+}

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -93,3 +93,7 @@ export function getPathToWorkspaceStorage(...args: string[]): string | undefined
     fse.ensureDirSync(EXTENSION_CONTEXT.storagePath);
     return path.join(EXTENSION_CONTEXT.storagePath, ...args);
 }
+
+export function localPomPath(gid: string, aid: string, version: string): string {
+    return path.join(getMavenLocalRepository(), ...gid.split("."), aid, version, `${aid}-${version}.pom`);
+}


### PR DESCRIPTION
this PR implements an inline command, jump to definition, for dependency node in sidebar. If click, it will open the pom file where the dependency is imported.


https://user-images.githubusercontent.com/25446374/126265383-c7a6b756-9207-4814-8eeb-b5db7929ff5e.mp4

