### PR TITLE
add conflictMessage in Dependency and implement fileDecoration

### DIFF
--- a/src/explorer/decorationProvider.ts
+++ b/src/explorer/decorationProvider.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import { Disposable } from "vscode";
 
 class DecorationProvider implements vscode.FileDecorationProvider {
-    private disposables: Disposable[] = [];
-    private decoration: vscode.FileDecoration = new vscode.FileDecoration("", "has conflicts", new vscode.ThemeColor("inputValidation.warningBorder"));
+    private disposables: vscode.Disposable[] = [];
+    private decoration: vscode.FileDecoration = {color: new vscode.ThemeColor("list.warningForeground")};
     constructor() {
         this.decoration.propagate = true;
         this.disposables.push(vscode.window.registerFileDecorationProvider(this));

--- a/src/explorer/decorationProvider.ts
+++ b/src/explorer/decorationProvider.ts
@@ -7,7 +7,6 @@ class DecorationProvider implements vscode.FileDecorationProvider {
     private disposables: vscode.Disposable[] = [];
     private decoration: vscode.FileDecoration = {color: new vscode.ThemeColor("list.warningForeground")};
     constructor() {
-        this.decoration.propagate = true;
         this.disposables.push(vscode.window.registerFileDecorationProvider(this));
     }
 

--- a/src/explorer/decorationProvider.ts
+++ b/src/explorer/decorationProvider.ts
@@ -12,13 +12,13 @@ class DecorationProvider implements vscode.FileDecorationProvider {
     }
 
     public provideFileDecoration(uri: vscode.Uri): vscode.ProviderResult<vscode.FileDecoration> {
-        const endWithMessage: string | undefined = uri.toString().split("/").pop();
-        if (endWithMessage === "hasConflict") {
+        if (uri.query === "hasConflict") {
             return this.decoration;
         } else {
             return null;
         }
     }
+
     public dispose(): void {
         this.disposables.forEach(d => d.dispose());
     }

--- a/src/explorer/decorationProvider.ts
+++ b/src/explorer/decorationProvider.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import { Disposable } from "vscode";
+
+class DecorationProvider implements vscode.FileDecorationProvider {
+    private disposables: Disposable[];
+    private decoration: vscode.FileDecoration = new vscode.FileDecoration("", "has conflicts", new vscode.ThemeColor("inputValidation.warningBorder"));
+    constructor() {
+        this.disposables = [];
+        this.decoration.propagate = true;
+        this.disposables.push(vscode.window.registerFileDecorationProvider(this));
+    }
+
+    public provideFileDecoration(uri: vscode.Uri): vscode.ProviderResult<vscode.FileDecoration> {
+        const endWithMessage: string | undefined = uri.toString().split("/").pop();
+        if (endWithMessage === "hasConflict") {
+            return this.decoration;
+        } else {
+            return null;
+        }
+    }
+    public dispose(): void {
+        this.disposables.forEach(d => d.dispose());
+    }
+}
+
+export const decorationProvider: DecorationProvider = new DecorationProvider();

--- a/src/explorer/decorationProvider.ts
+++ b/src/explorer/decorationProvider.ts
@@ -5,10 +5,9 @@ import * as vscode from "vscode";
 import { Disposable } from "vscode";
 
 class DecorationProvider implements vscode.FileDecorationProvider {
-    private disposables: Disposable[];
+    private disposables: Disposable[] = [];
     private decoration: vscode.FileDecoration = new vscode.FileDecoration("", "has conflicts", new vscode.ThemeColor("inputValidation.warningBorder"));
     constructor() {
-        this.disposables = [];
         this.decoration.propagate = true;
         this.disposables.push(vscode.window.registerFileDecorationProvider(this));
     }

--- a/src/explorer/model/DependenciesMenu.ts
+++ b/src/explorer/model/DependenciesMenu.ts
@@ -27,7 +27,7 @@ export class DependenciesMenu extends Menu implements ITreeItem {
     public getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
         const treeItem: vscode.TreeItem = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
         const uri: vscode.Uri = vscode.Uri.file("");
-        treeItem.resourceUri = uri.with({authority: this.project.pomPath});
+        treeItem.resourceUri = uri.with({authority: this.project.pomPath}); // distinguish dependenciesMenu in multi-module project
         treeItem.tooltip = this.name;
         const iconFile: string = "library-folder.svg";
         treeItem.iconPath = {

--- a/src/explorer/model/DependenciesMenu.ts
+++ b/src/explorer/model/DependenciesMenu.ts
@@ -26,6 +26,9 @@ export class DependenciesMenu extends Menu implements ITreeItem {
 
     public getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
         const treeItem: vscode.TreeItem = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
+        const uri: vscode.Uri = vscode.Uri.file("");
+        treeItem.resourceUri = uri.with({authority: this.project.pomPath});
+        treeItem.tooltip = this.name;
         const iconFile: string = "library-folder.svg";
         treeItem.iconPath = {
             light: getPathToExtensionRoot("resources", "icons", "light", iconFile),

--- a/src/explorer/model/Dependency.ts
+++ b/src/explorer/model/Dependency.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import { getPathToExtensionRoot, localPomPath } from "../../utils/contextUtils";
-import { IConflictMessage } from "./IConflictMessage";
+import { getPathToExtensionRoot } from "../../utils/contextUtils";
 import { ITreeItem } from "./ITreeItem";
 import { IOmittedStatus } from "./OmittedStatus";
 import { TreeNode } from "./TreeNode";
@@ -16,7 +15,7 @@ export class Dependency extends TreeNode implements ITreeItem {
     private _version: string;
     private _scope: string;
     private _omittedStatus: IOmittedStatus;
-    public conflictMessages: IConflictMessage[] = [];
+    private _uri: vscode.Uri;
     constructor(gid: string, aid: string, version: string, scope: string, omittedStatus: IOmittedStatus, projectPomPath: string) {
         super();
         this._gid = gid;
@@ -26,10 +25,6 @@ export class Dependency extends TreeNode implements ITreeItem {
         this.fullArtifactName = [gid, aid, version, scope].join(":");
         this._omittedStatus = omittedStatus;
         this._projectPomPath = projectPomPath;
-        if (omittedStatus.status === "conflict") {
-            const conflictMessage: IConflictMessage = {gid: gid, aid: aid, version1: version, version2: omittedStatus.effectiveVersion};
-            this.conflictMessages.push(conflictMessage);
-        }
     }
     public get omittedStatus(): IOmittedStatus {
         return this._omittedStatus;
@@ -57,13 +52,11 @@ export class Dependency extends TreeNode implements ITreeItem {
     }
 
     public get uri(): vscode.Uri {
-        const filePath: string = localPomPath(this._gid, this._aid, this._version);
-        let uri: vscode.Uri = vscode.Uri.file(filePath);
-        uri = uri.with({authority: this.projectPomPath});
-        if (this.conflictMessages.length !== 0) {
-            uri = vscode.Uri.joinPath(uri, "hasConflict");
-        }
-        return uri;
+        return this._uri;
+    }
+
+    public set uri(uri: vscode.Uri) {
+        this._uri = uri;
     }
 
     public getContextValue(): string {
@@ -77,6 +70,7 @@ export class Dependency extends TreeNode implements ITreeItem {
     public getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
         const treeItem: vscode.TreeItem = new vscode.TreeItem(this.fullArtifactName);
         treeItem.resourceUri = this.uri;
+        treeItem.tooltip = this.fullArtifactName;
         if (this.children.length !== 0) {
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
         } else {

--- a/src/explorer/model/IConflictMessage.ts
+++ b/src/explorer/model/IConflictMessage.ts
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
-export interface IConflictMessage {
-    gid: string;
-    aid: string;
-    version1: string;
-    version2: string;
-}

--- a/src/explorer/model/IConflictMessage.ts
+++ b/src/explorer/model/IConflictMessage.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export interface IConflictMessage {
+    gid: string;
+    aid: string;
+    version1: string;
+    version2: string;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { codeActionProvider } from "./codeAction/codeActionProvider";
 import { completionProvider } from "./completion/completionProvider";
 import { definitionProvider } from "./definition/definitionProvider";
 import { initExpService } from "./experimentationService";
+import { decorationProvider } from "./explorer/decorationProvider";
 import { mavenExplorerProvider } from "./explorer/mavenExplorerProvider";
 import { ITreeItem } from "./explorer/model/ITreeItem";
 import { MavenProject } from "./explorer/model/MavenProject";
@@ -136,6 +137,8 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     if (isJavaExtEnabled()) {
         registerArtifactSearcher(context);
     }
+    //fileDecoration
+    context.subscriptions.push(decorationProvider);
 }
 
 function registerPomFileWatcher(context: vscode.ExtensionContext): void {

--- a/src/handlers/parseRawDependencyDataHandler.ts
+++ b/src/handlers/parseRawDependencyDataHandler.ts
@@ -74,7 +74,7 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
                 curNode.root = curNode;
                 rootNode = curNode;
                 parentNode = curNode;
-                curFilePath = path.join(`${curNode.groupId}`, `${curNode.artifactId}`);
+                curFilePath = path.join(curNode.groupId, curNode.artifactId);
             } else {
                 curNode.root = rootNode;
                 if (curIndentCnt === preIndentCnt) {
@@ -90,7 +90,7 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
                     parentNode.addChild(curNode);
                 }
                 const parentFilePath: string = parentNode.uri.path;
-                curFilePath = path.join(parentFilePath, path.join(`${curNode.groupId}`, `${curNode.artifactId}`));
+                curFilePath = path.join(parentFilePath, path.join(curNode.groupId, curNode.artifactId));
             }
             // set uri
             uri = vscode.Uri.file(curFilePath);

--- a/src/handlers/parseRawDependencyDataHandler.ts
+++ b/src/handlers/parseRawDependencyDataHandler.ts
@@ -42,12 +42,13 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
         let preIndentCnt: number;
         const lines: string[] = treecontent.split(eol).splice(1); // delete project name
         const toDependency = (line: string): Dependency => {
-            let name: string = line.slice(curIndentCnt + prefix.length);
-            const indexCut: number = name.indexOf("(");
+            const fullName: string = line.slice(curIndentCnt + prefix.length);
+            let name: string = fullName;
+            const indexCut: number = fullName.indexOf("(");
             let supplement: string = "";
             if (indexCut !== -1) {
-                supplement = name.substr(indexCut);
-                name = name.substr(0, indexCut);
+                supplement = fullName.substr(indexCut);
+                name = fullName.substr(0, indexCut);
             }
             const [gid, aid, version, scope] = name.split(":");
             let effectiveVersion: string;
@@ -83,6 +84,15 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
                         parentNode = <Dependency> parentNode.parent;
                     }
                     parentNode.addChild(curNode);
+                }
+                if (curNode.conflictMessages.length !== 0) {
+                    let tmpNode = curNode;
+                    const message = tmpNode.conflictMessages;
+                    while (tmpNode.parent !== undefined) {
+                        const parent = <Dependency> tmpNode.parent;
+                        parent.conflictMessages = parent.conflictMessages.concat(message);
+                        tmpNode = parent;
+                    }
                 }
             }
             if (curIndentCnt === 0) {

--- a/src/handlers/parseRawDependencyDataHandler.ts
+++ b/src/handlers/parseRawDependencyDataHandler.ts
@@ -42,13 +42,12 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
         let preIndentCnt: number;
         const lines: string[] = treecontent.split(eol).splice(1); // delete project name
         const toDependency = (line: string): Dependency => {
-            const fullName: string = line.slice(curIndentCnt + prefix.length);
-            let name: string = fullName;
-            const indexCut: number = fullName.indexOf("(");
+            let name: string = line.slice(curIndentCnt + prefix.length);
+            const indexCut: number = name.indexOf("(");
             let supplement: string = "";
             if (indexCut !== -1) {
-                supplement = fullName.substr(indexCut);
-                name = fullName.substr(0, indexCut);
+                supplement = name.substr(indexCut);
+                name = name.substr(0, indexCut);
             }
             const [gid, aid, version, scope] = name.split(":");
             let effectiveVersion: string;

--- a/src/handlers/parseRawDependencyDataHandler.ts
+++ b/src/handlers/parseRawDependencyDataHandler.ts
@@ -74,7 +74,7 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
                 curNode.root = curNode;
                 rootNode = curNode;
                 parentNode = curNode;
-                curFilePath = `${curNode.groupId}.${curNode.artifactId}`;
+                curFilePath = path.join(`${curNode.groupId}`, `${curNode.artifactId}`);
             } else {
                 curNode.root = rootNode;
                 if (curIndentCnt === preIndentCnt) {
@@ -90,7 +90,7 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
                     parentNode.addChild(curNode);
                 }
                 const parentFilePath: string = parentNode.uri.path;
-                curFilePath = path.join(parentFilePath, `${curNode.groupId}.${curNode.artifactId}`);
+                curFilePath = path.join(parentFilePath, path.join(`${curNode.groupId}`, `${curNode.artifactId}`));
             }
             // set uri
             uri = vscode.Uri.file(curFilePath);
@@ -103,8 +103,10 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
                     const parent = <Dependency> tmpNode.parent;
                     if (parent.uri.query !== "hasConflict") {
                         parent.uri = uri.with({query: "hasConflict"});
+                        tmpNode = parent;
+                    } else {
+                        break;
                     }
-                    tmpNode = parent;
                 }
             } else {
                 curNode.uri = uri;

--- a/src/handlers/parseRawDependencyDataHandler.ts
+++ b/src/handlers/parseRawDependencyDataHandler.ts
@@ -94,7 +94,7 @@ function parseTreeNodes(treecontent: string, eol: string, indent: string, prefix
             }
             // set uri
             uri = vscode.Uri.file(curFilePath);
-            uri = uri.with({authority: projectPomPath});
+            uri = uri.with({authority: projectPomPath}); // distinguish dependency in multi-module project
             if (curNode.omittedStatus.status === "conflict") {
                 curNode.uri = uri.with({query: "hasConflict"});
                 // find all parent and set hasConflict upforward


### PR DESCRIPTION
This pr adds a new parameter in class `Dependency` to track conflicts for both fileDecoration and diagnostics.

Also, it colors the items that have conflicts to make them more conspicuous.

part of #261 

![image](https://user-images.githubusercontent.com/25446374/126749728-c64054c5-3743-49dd-9465-c35fdcfcb647.png)
