### PR TITLE
load maven.terminal.customEnv for background maven commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Now right-click on an project item, and then click `Favorite ...`. The option `f
 | `maven.pomfile.autoUpdateEffectivePOM` | Specifies whether to update effective-pom automatically whenever changes detected. | `false` |
 | `maven.pomfile.globPattern` | Specifies the glob pattern used to look for pom.xml files. | `**/pom.xml` |
 | `maven.terminal.useJavaHome` | If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created. | `false` |
-| `maven.terminal.customEnv` | Specifies an array of environment variable names and values. These environment variable values will be added to the terminal session before Maven is first executed. <br /> `environmentVariable`: Name of the environment variable to set. <br /> `value`: Value of the environment variable to set. | `[]` |
+| `maven.terminal.customEnv` | Specifies an array of environment variable names and values. These environment variable values will be added before Maven is executed. <br /> `environmentVariable`: Name of the environment variable to set. <br /> `value`: Value of the environment variable to set. | `[]` |
 | `maven.terminal.favorites` | Specify pre-defined favorite commands to execute. <br /> `alias`: A short name for the command. <br /> `command`: Content of the favorite command. | `[]` |
 | `maven.view` | Specifies the way of viewing Maven projects. Possible values: `flat`, `hierarchical`. | `flat` |
 | `maven.settingsFile` | Specifies the absolute path of Maven `settings.xml` file. If not specified, `~/.m2/settings.xml` is used. | `null` |

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -70,7 +70,7 @@ async function executeInBackground(mvnArgs: string, pomfile?: string): Promise<a
     }
     const spawnOptions: child_process.SpawnOptions = {
         cwd,
-        env: process.env,
+        env: Object.assign({}, process.env, Settings.getEnvironment(pomfile)),
         shell: true
     };
     return new Promise<{}>((resolve: (value: any) => void, reject: (e: Error) => void): void => {


### PR DESCRIPTION
Fix #637 as workspace trust has been shipped. Some users use `customEnv` to set JAVA_HOME for maven to execute. Previously it's disabled for background processes for security concern. 
