### PR TITLE
use content provider to open epom and dependencies

### DIFF
--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -10,7 +10,7 @@ import { Utils } from "./utils/Utils";
 
 class MavenContentProvider implements vscode.TextDocumentContentProvider {
     public async provideTextDocumentContent(uri: vscode.Uri, _token: vscode.CancellationToken): Promise<string | undefined> {
-        if (uri.scheme !== "maven") {
+        if (uri.scheme !== "vscode-maven") {
             throw new Error(`Scheme ${uri.scheme} not supported by this content provider.`);
         }
 

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import { mavenExplorerProvider } from "./explorer/mavenExplorerProvider";
+import { IEffectivePom } from "./explorer/model/IEffectivePom";
+import { MavenProject } from "./explorer/model/MavenProject";
+import { getDependencyTree } from "./handlers/showDependenciesHandler";
+import { Utils } from "./utils/Utils";
+
+class MavenContentProvider implements vscode.TextDocumentContentProvider {
+    public async provideTextDocumentContent(uri: vscode.Uri, _token: vscode.CancellationToken): Promise<string | undefined> {
+        if (uri.scheme !== "maven") {
+            throw new Error(`Scheme ${uri.scheme} not supported by this content provider.`);
+        }
+
+        const pomPath = uri.query;
+        switch (uri.authority) {
+            case "dependencies":
+                return getDependencyTree(pomPath);
+            case "effective-pom":
+                const project: MavenProject | undefined = mavenExplorerProvider.getMavenProject(pomPath);
+                if (project) {
+                    const effectivePom: IEffectivePom = await project.getEffectivePom();
+                    return effectivePom.ePomString;
+                } else {
+                    return Utils.getEffectivePom(pomPath);
+                }
+            default:
+        }
+        return undefined;
+
+    }
+}
+
+export const contentProvider: MavenContentProvider = new MavenContentProvider();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { ArchetypeModule } from "./archetype/ArchetypeModule";
 import { codeActionProvider } from "./codeAction/codeActionProvider";
 import { ConflictResolver, conflictResolver } from "./codeAction/conflictResolver";
 import { completionProvider } from "./completion/completionProvider";
+import { contentProvider } from "./contentProvider";
 import { definitionProvider } from "./definition/definitionProvider";
 import { diagnosticProvider } from "./DiagnosticProvider";
 import { initExpService } from "./experimentationService";
@@ -144,6 +145,8 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     diagnosticProvider.initialize(context);
     //fileDecoration
     context.subscriptions.push(decorationProvider);
+    //textDocument based output (e.g. effective-pom, dependencies)
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider("maven", contentProvider));
 }
 
 function registerPomFileWatcher(context: vscode.ExtensionContext): void {

--- a/src/handlers/showDependenciesHandler.ts
+++ b/src/handlers/showDependenciesHandler.ts
@@ -9,7 +9,7 @@ import { rawDependencyTree } from "../utils/mavenUtils";
 
 export async function showDependenciesHandler(project: MavenProject): Promise<void> {
     const displayName = `Dependencies`;
-    const uri = vscode.Uri.parse("maven://dependencies").with({path: "/" + path.join(project.pomPath, displayName), query: project.pomPath});
+    const uri = vscode.Uri.parse("vscode-maven://dependencies").with({path: "/" + path.join(project.pomPath, displayName), query: project.pomPath});
     await vscode.window.showTextDocument(uri);
 }
 

--- a/src/handlers/showDependenciesHandler.ts
+++ b/src/handlers/showDependenciesHandler.ts
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as path from "path";
 import * as vscode from "vscode";
 import { setUserError } from "vscode-extension-telemetry-wrapper";
 import { MavenProject } from "../explorer/model/MavenProject";
 import { rawDependencyTree } from "../utils/mavenUtils";
 
 export async function showDependenciesHandler(project: MavenProject): Promise<void> {
-    const dependencyTree : string | undefined = await getDependencyTree(project);
-    if (dependencyTree === undefined) {
-        throw new Error("Failed to generate dependency tree.");
-    }
-
-    const treeContent: string = dependencyTree.replace(/\|/g, " ");
-    const document: vscode.TextDocument = await vscode.workspace.openTextDocument({ language: "plain", content: treeContent });
-    await vscode.window.showTextDocument(document, { viewColumn: vscode.ViewColumn.Active, preview: false });
+    const displayName = `Dependencies`;
+    const uri = vscode.Uri.parse("maven://dependencies").with({path: "/" + path.join(project.pomPath, displayName), query: project.pomPath});
+    await vscode.window.showTextDocument(uri);
 }
 
 export async function getDependencyTree(pomPathOrMavenProject: string | MavenProject): Promise<string | undefined> {

--- a/src/handlers/showDependenciesHandler.ts
+++ b/src/handlers/showDependenciesHandler.ts
@@ -8,8 +8,8 @@ import { MavenProject } from "../explorer/model/MavenProject";
 import { rawDependencyTree } from "../utils/mavenUtils";
 
 export async function showDependenciesHandler(project: MavenProject): Promise<void> {
-    const displayName = `Dependencies`;
-    const uri = vscode.Uri.parse("vscode-maven://dependencies").with({path: "/" + path.join(project.pomPath, displayName), query: project.pomPath});
+    const displayName = "Dependencies";
+    const uri = vscode.Uri.parse("vscode-maven://dependencies").with({path: `/${path.join(project.pomPath, displayName)}`, query: project.pomPath});
     await vscode.window.showTextDocument(uri);
 }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -7,11 +7,10 @@ import * as https from "https";
 import * as md5 from "md5";
 import * as path from "path";
 import * as url from "url";
-import { commands, Progress, ProgressLocation, RelativePattern, TextDocument, Uri, ViewColumn, window, workspace, WorkspaceFolder } from "vscode";
+import { commands, Progress, ProgressLocation, RelativePattern, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { createUuid, setUserError } from "vscode-extension-telemetry-wrapper";
 import * as xml2js from "xml2js";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
-import { IEffectivePom } from "../explorer/model/IEffectivePom";
 import { LifecyclePhase } from "../explorer/model/LifecyclePhase";
 import { MavenProject } from "../explorer/model/MavenProject";
 import { Settings } from "../Settings";
@@ -136,22 +135,9 @@ export namespace Utils {
             throw new MavenNotFoundError();
         }
 
-        let pomxml: string | undefined;
-        const project: MavenProject | undefined = mavenExplorerProvider.getMavenProject(pomPath);
-        if (project) {
-            const effectivePom: IEffectivePom = await project.getEffectivePom();
-            pomxml = effectivePom.ePomString;
-        } else {
-            pomxml = await getEffectivePom(pomPath);
-        }
-        if (!pomxml) {
-            const error: Error = new Error("Fail to get effective pom.");
-            setUserError(error);
-            throw error;
-        }
-
-        const document: TextDocument = await workspace.openTextDocument({ language: "xml", content: pomxml });
-        await window.showTextDocument(document, ViewColumn.Active);
+        const displayName = "EffectivePOM.xml";
+        const uri = Uri.parse("maven://effective-pom").with({ path: "/" + path.join(pomPath, displayName), query: pomPath });
+        await window.showTextDocument(uri);
     }
 
     export async function getEffectivePom(pomPathOrMavenProject: string | MavenProject): Promise<string | undefined> {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -136,7 +136,7 @@ export namespace Utils {
         }
 
         const displayName = "EffectivePOM.xml";
-        const uri = Uri.parse("maven://effective-pom").with({ path: "/" + path.join(pomPath, displayName), query: pomPath });
+        const uri = Uri.parse("vscode-maven://effective-pom").with({ path: "/" + path.join(pomPath, displayName), query: pomPath });
         await window.showTextDocument(uri);
     }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -136,7 +136,7 @@ export namespace Utils {
         }
 
         const displayName = "EffectivePOM.xml";
-        const uri = Uri.parse("vscode-maven://effective-pom").with({ path: "/" + path.join(pomPath, displayName), query: pomPath });
+        const uri = Uri.parse("vscode-maven://effective-pom").with({ path: `/${path.join(pomPath, displayName)}`, query: pomPath });
         await window.showTextDocument(uri);
     }
 


### PR DESCRIPTION
Previously opened as an untitled file, which has below disadvantages:
- unreadable title
- prompt for saving on closing file

Now use content provider for better UX.

