### PR TITLE
fix: epom cache was never updated

### DIFF
--- a/src/explorer/EffectivePomProvider.ts
+++ b/src/explorer/EffectivePomProvider.ts
@@ -8,18 +8,15 @@ import { IEffectivePom } from "./model/IEffectivePom";
 
 export class EffectivePomProvider {
   private pomPath: string;
-  private effectivePom: IEffectivePom;
   private emitter: EventEmitter = new EventEmitter();
   private isCalculating: boolean = false;
 
   constructor(pomPath: string) {
     this.pomPath = pomPath;
-    this.emitter.on("complete", (resp: IEffectivePom) => {
-      this.effectivePom = resp;
+    this.emitter.on("complete", (_resp: IEffectivePom) => {
       this.isCalculating = false;
     });
     this.emitter.on("error", (_error) => {
-      this.effectivePom = { pomPath };
       this.isCalculating = false;
     });
   }
@@ -63,10 +60,6 @@ export class EffectivePomProvider {
 
     if (this.isCalculating) {
       return promise;
-    }
-
-    if (this.effectivePom !== undefined) {
-      return this.effectivePom;
     }
 
     this.calculateEffectivePom(options).catch(console.error);

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -24,18 +24,19 @@ import { updateLRUCommands } from "./historyUtils";
  */
 export async function rawEffectivePom(pomPath: string, options?: {cacheOnly?: boolean}): Promise<string | undefined> {
     const outputPath: string = getTempFolder(pomPath);
+    const epomPath: string = `${outputPath}.epom`;
     const mtimePath: string = `${outputPath}.mtime`;
     const cachedMTimeMs: string | undefined = await readFileIfExists(mtimePath);
     const stat: fse.Stats = await fse.stat(pomPath);
     const mtimeMs: string = stat.mtimeMs.toString();
 
     if (cachedMTimeMs === mtimeMs || options?.cacheOnly) {
-        return await readFileIfExists(outputPath);
+        return await readFileIfExists(epomPath);
     }
 
-    await executeInBackground(`help:effective-pom -Doutput="${outputPath}"`, pomPath);
+    await executeInBackground(`help:effective-pom -Doutput="${epomPath}"`, pomPath);
     await fse.writeFile(mtimePath, mtimeMs);
-    return await readFileIfExists(outputPath);
+    return await readFileIfExists(epomPath);
 }
 
 export async function rawDependencyTree(pomPath: string): Promise<any> {


### PR DESCRIPTION
```
if (this.effectivePom !== undefined) {
      return this.effectivePom;
    }
```

Once calculated, effective pom was never updated when pom.xml changed. Now removing this part, as we have FS level epom cache based on timestamp