### PR TITLE
notify content provider on pomxml change

### DIFF
--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -10,7 +10,7 @@ import { Utils } from "./utils/Utils";
 
 class MavenContentProvider implements vscode.TextDocumentContentProvider {
 
-    readonly onDidChange: vscode.Event<vscode.Uri>;
+    public readonly onDidChange: vscode.Event<vscode.Uri>;
     private _onDidChangeEmitter: vscode.EventEmitter<vscode.Uri>;
 
     constructor() {
@@ -18,7 +18,7 @@ class MavenContentProvider implements vscode.TextDocumentContentProvider {
         this.onDidChange = this._onDidChangeEmitter.event;
     }
 
-    public invalidate(uri: vscode.Uri) {
+    public invalidate(uri: vscode.Uri): void {
         this._onDidChangeEmitter.fire(uri);
     }
 

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -9,6 +9,19 @@ import { getDependencyTree } from "./handlers/showDependenciesHandler";
 import { Utils } from "./utils/Utils";
 
 class MavenContentProvider implements vscode.TextDocumentContentProvider {
+
+    readonly onDidChange: vscode.Event<vscode.Uri>;
+    private _onDidChangeEmitter: vscode.EventEmitter<vscode.Uri>;
+
+    constructor() {
+        this._onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+        this.onDidChange = this._onDidChangeEmitter.event;
+    }
+
+    public invalidate(uri: vscode.Uri) {
+        this._onDidChangeEmitter.fire(uri);
+    }
+
     public async provideTextDocumentContent(uri: vscode.Uri, _token: vscode.CancellationToken): Promise<string | undefined> {
         if (uri.scheme !== "vscode-maven") {
             throw new Error(`Scheme ${uri.scheme} not supported by this content provider.`);

--- a/src/handlers/showDependenciesHandler.ts
+++ b/src/handlers/showDependenciesHandler.ts
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as path from "path";
 import * as vscode from "vscode";
 import { setUserError } from "vscode-extension-telemetry-wrapper";
 import { MavenProject } from "../explorer/model/MavenProject";
 import { rawDependencyTree } from "../utils/mavenUtils";
+import { dependenciesContentUri } from "../utils/uiUtils";
 
 export async function showDependenciesHandler(project: MavenProject): Promise<void> {
-    const displayName = "Dependencies";
-    const uri = vscode.Uri.parse("vscode-maven://dependencies").with({path: `/${path.join(project.pomPath, displayName)}`, query: project.pomPath});
+    const uri = dependenciesContentUri(project.pomPath);
     await vscode.window.showTextDocument(uri);
 }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -18,7 +18,7 @@ import { getExtensionVersion, getPathToTempFolder, getPathToWorkspaceStorage } f
 import { MavenNotFoundError } from "./errorUtils";
 import { getLRUCommands, ICommandHistoryEntry } from "./historyUtils";
 import { executeInTerminal, getMaven, pluginDescription, rawEffectivePom } from "./mavenUtils";
-import { selectProjectIfNecessary } from "./uiUtils";
+import { effectivePomContentUri, selectProjectIfNecessary } from "./uiUtils";
 
 export namespace Utils {
 
@@ -135,8 +135,7 @@ export namespace Utils {
             throw new MavenNotFoundError();
         }
 
-        const displayName = "EffectivePOM.xml";
-        const uri = Uri.parse("vscode-maven://effective-pom").with({ path: `/${path.join(pomPath, displayName)}`, query: pomPath });
+        const uri = effectivePomContentUri(pomPath);
         await window.showTextDocument(uri);
     }
 

--- a/src/utils/uiUtils.ts
+++ b/src/utils/uiUtils.ts
@@ -3,6 +3,7 @@
 
 import * as fs from "fs-extra";
 import * as vscode from "vscode";
+import * as path from "path";
 import { OpenDialogOptions, Uri, window } from "vscode";
 import { instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
@@ -109,4 +110,14 @@ async function promptToManageWorkspaceTrust(): Promise<void> {
     if (choiceForDetails === OPTION_MANAGE_TRUST) {
         vscode.commands.executeCommand(COMMAND_MANAGE_TRUST);
     }
+}
+
+export function effectivePomContentUri(pomPath: string) {
+    const displayName = "EffectivePOM.xml";
+    return Uri.parse("vscode-maven://effective-pom").with({ path: `/${path.join(pomPath, displayName)}`, query: pomPath });
+}
+
+export function dependenciesContentUri(pomPath: string) {
+    const displayName = "Dependencies";
+    return vscode.Uri.parse("vscode-maven://dependencies").with({ path: `/${path.join(pomPath, displayName)}`, query: pomPath });
 }

--- a/src/utils/uiUtils.ts
+++ b/src/utils/uiUtils.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import * as fs from "fs-extra";
-import * as vscode from "vscode";
 import * as path from "path";
+import * as vscode from "vscode";
 import { OpenDialogOptions, Uri, window } from "vscode";
 import { instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
@@ -112,12 +112,12 @@ async function promptToManageWorkspaceTrust(): Promise<void> {
     }
 }
 
-export function effectivePomContentUri(pomPath: string) {
+export function effectivePomContentUri(pomPath: string): vscode.Uri {
     const displayName = "EffectivePOM.xml";
     return Uri.parse("vscode-maven://effective-pom").with({ path: `/${path.join(pomPath, displayName)}`, query: pomPath });
 }
 
-export function dependenciesContentUri(pomPath: string) {
+export function dependenciesContentUri(pomPath: string): vscode.Uri {
     const displayName = "Dependencies";
     return vscode.Uri.parse("vscode-maven://dependencies").with({ path: `/${path.join(pomPath, displayName)}`, query: pomPath });
 }


### PR DESCRIPTION
vscode seems to cache the content for the same Uri. Whenever pom.xml changes, we should notify it, to update dependencies and epom.