### PR TITLE
use SemVer lib to compare versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lodash": "^4.17.21",
         "md5": "^2.2.1",
         "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
         "vscode-extension-telemetry-wrapper": "^0.9.0",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver-protocol": "^3.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/minimatch": "^3.0.4",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.14.37",
+        "@types/semver": "^7.3.8",
         "@types/vscode": "1.56.0",
         "@types/which": "^1.3.2",
         "@types/xml-zero-lexer": "^2.1.0",
@@ -199,6 +200,12 @@
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
       "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -4897,6 +4904,12 @@
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
       "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
       "dev": true
     },
     "@types/vscode": {

--- a/package.json
+++ b/package.json
@@ -684,6 +684,7 @@
     "@types/minimatch": "^3.0.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.14.37",
+    "@types/semver": "^7.3.8",
     "@types/vscode": "1.56.0",
     "@types/which": "^1.3.2",
     "@types/xml-zero-lexer": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -708,6 +708,7 @@
     "lodash": "^4.17.21",
     "md5": "^2.2.1",
     "minimatch": "^3.0.4",
+    "semver": "^5.6.0",
     "vscode-extension-telemetry-wrapper": "^0.9.0",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver-protocol": "^3.16.0",

--- a/src/handlers/setDependencyVersionHandler.ts
+++ b/src/handlers/setDependencyVersionHandler.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as fse from "fs-extra";
+import * as semver from "semver";
 import * as vscode from "vscode";
 import { mavenExplorerProvider } from "../explorer/mavenExplorerProvider";
 import { Dependency } from "../explorer/model/Dependency";
@@ -164,28 +165,12 @@ function getAllVersionsInTree(pomPath: string, gid: string, aid: string): string
     }
 
     function compare(v1: string, v2: string): number {
-        const indexCut1: number = v1.indexOf("-"); // filter char
-        const indexCut2: number = v2.indexOf("-");
-        if (indexCut1 !== -1) {
-            v1 = v1.substr(0, indexCut1);
-        }
-        if (indexCut2 !== -1) {
-            v2 = v2.substr(0, indexCut2);
-        }
-        const numbers1: number[] = v1.split(".").map(Number);
-        const numbers2: number[] = v2.split(".").map(Number);
-        const minLen: number = numbers1.length < numbers2.length ? numbers1.length : numbers2.length;
-        let i: number = 0;
-        while (i < minLen) {
-            if (numbers1[i] < numbers2[i]) {
-                return 1;
-            } else if (numbers1[i] > numbers2[i]) {
-                return -1;
-            } else {
-                i += 1;
-            }
-        }
-        return 0;
+        // correct versions that do not follow SemVer Policy
+        const s1: semver.SemVer | null = semver.coerce(v1);
+        const s2: semver.SemVer | null = semver.coerce(v2);
+        const version1: semver.SemVer | string = s1 === null ? v1 : s1;
+        const version2: semver.SemVer | string = s2 === null ? v2 : s2;
+        return semver.rcompare(version1, version2);
     }
 
     versions = Array.from(new Set(versions)).sort(compare);

--- a/src/handlers/setDependencyVersionHandler.ts
+++ b/src/handlers/setDependencyVersionHandler.ts
@@ -170,7 +170,7 @@ function getAllVersionsInTree(pomPath: string, gid: string, aid: string): string
         const s2: semver.SemVer | null = semver.coerce(v2);
         const version1: semver.SemVer | string = s1 === null ? v1 : s1;
         const version2: semver.SemVer | string = s2 === null ? v2 : s2;
-        return semver.rcompare(version1, version2);
+        return semver.rcompare(version1, version2, true);
     }
 
     versions = Array.from(new Set(versions)).sort(compare);


### PR DESCRIPTION
fix #669. use `SemVer` lib to compare dependency versions. For those who do not follow SemVer policy, correct them and then compare.