### PR TITLE
fix: apply #690 to other features

### DIFF
--- a/src/handlers/excludeDependencyHandler.ts
+++ b/src/handlers/excludeDependencyHandler.ts
@@ -26,8 +26,8 @@ export async function excludeDependencyHandler(toExclude?: Dependency): Promise<
 
 async function excludeDependency(pomPath: string, gid: string, aid: string, rootGid: string, rootAid: string): Promise<void> {
     //find out <dependencies> node with artifactId === rootAid and insert <exclusions> node
-    const contentBuf: Buffer = await fse.readFile(pomPath);
-    const projectNodes: ElementNode[] = getNodesByTag(contentBuf.toString(), XmlTagName.Project);
+    const pomDocument = await vscode.window.showTextDocument(vscode.Uri.file(pomPath), {preserveFocus: true});
+    const projectNodes: ElementNode[] = getNodesByTag(pomDocument.document.getText(), XmlTagName.Project);
     if (projectNodes === undefined || projectNodes.length !== 1) {
         throw new UserError("Only support POM file with single <project> node.");
     }

--- a/src/handlers/jumpToDefinitionHandler.ts
+++ b/src/handlers/jumpToDefinitionHandler.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as fse from "fs-extra";
 import * as vscode from "vscode";
 import { Dependency } from "../explorer/model/Dependency";
 import { localPomPath } from "../utils/contextUtils";
@@ -24,8 +23,8 @@ export async function jumpToDefinitionHandler(node?: Dependency): Promise<void> 
 }
 
 async function goToDefinition(pomPath: string, gid: string, aid: string): Promise<void> {
-    const contentBuf: Buffer = await fse.readFile(pomPath);
-    const projectNodes: ElementNode[] = getNodesByTag(contentBuf.toString(), XmlTagName.Project);
+    const pomDocument = await vscode.window.showTextDocument(vscode.Uri.file(pomPath), {preserveFocus: true});
+    const projectNodes: ElementNode[] = getNodesByTag(pomDocument.document.getText(), XmlTagName.Project);
     if (projectNodes === undefined || projectNodes.length !== 1) {
         throw new UserError("Only support POM file with single <project> node.");
     }

--- a/src/handlers/setDependencyVersionHandler.ts
+++ b/src/handlers/setDependencyVersionHandler.ts
@@ -59,8 +59,8 @@ export async function setDependencyVersionHandler(selectedItem?: any): Promise<v
 }
 
 async function setDependencyVersion(pomPath: string, gid: string, aid: string, version: string): Promise<void> {
-    const contentBuf: Buffer = await fse.readFile(pomPath);
-    const projectNodes: ElementNode[] = getNodesByTag(contentBuf.toString(), XmlTagName.Project);
+    const pomDocument = await vscode.window.showTextDocument(vscode.Uri.file(pomPath), {preserveFocus: true});
+    const projectNodes: ElementNode[] = getNodesByTag(pomDocument.document.getText(), XmlTagName.Project);
     if (projectNodes === undefined || projectNodes.length !== 1) {
         throw new UserError("Only support POM file with single <project> node.");
     }


### PR DESCRIPTION
fix: insert malformed dependency when pom.xml is dirty for "exclude dependency", "set dependency version" and "go to definition" features.