### PR TITLE
fix error on creating project when empty workspace is open

### DIFF
--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -18,7 +18,7 @@ const REMOTE_ARCHETYPE_CATALOG_URL: string = "https://repo.maven.apache.org/mave
 export namespace ArchetypeModule {
 
     export async function createMavenProject(entry: Uri | undefined, _operationId: string): Promise<void> {
-        const targetFolder: string | undefined = entry?.fsPath ?? workspace.workspaceFolders?.[0].uri.fsPath;
+        const targetFolder: string | undefined = entry?.fsPath ?? workspace.workspaceFolders?.[0]?.uri.fsPath;
         // default metadata
         const metadata: IProjectCreationMetadata = {
             targetFolder,


### PR DESCRIPTION
See #689

we didn't cover the case when `vscode.workspace.workspaceFolder` is en empty array.