### PR TITLE
refine right-click command entry for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,7 +454,7 @@
         },
         {
           "command": "maven.project.setDependencyVersion",
-          "when": "view == mavenProjects && viewItem == Dependency",
+          "when": "view == mavenProjects && viewItem =~ /\\w*Dependency/",
           "group": "0-dependency@1"
         },
         {

--- a/package.json
+++ b/package.json
@@ -449,7 +449,7 @@
         },
         {
           "command": "maven.project.excludeDependency",
-          "when": "viewItem == Dependency || viewItem == conflictDependency && view == mavenProjects",
+          "when": "view == mavenProjects && viewItem =~ /^(Dependency)|(conflictDependency)$/",
           "group": "0-dependency@0"
         },
         {

--- a/package.json
+++ b/package.json
@@ -449,12 +449,12 @@
         },
         {
           "command": "maven.project.excludeDependency",
-          "when": "view == mavenProjects && viewItem == Dependency",
+          "when": "viewItem == Dependency || viewItem == conflictDependency && view == mavenProjects",
           "group": "0-dependency@0"
         },
         {
           "command": "maven.project.setDependencyVersion",
-          "when": "view == mavenProjects && viewItem =~ /\\w*Dependency/",
+          "when": "view == mavenProjects && viewItem == conflictDependency",
           "group": "0-dependency@1"
         },
         {

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,7 +16,7 @@
     "contributes.commands.maven.project.addDependency": "Add a dependency...",
     "contributes.commands.maven.project.showDependencies": "Show dependencies",
     "contributes.commands.maven.project.excludeDependency": "Exclude dependency",
-    "contributes.commands.maven.project.setDependencyVersion": "Set version to...",
+    "contributes.commands.maven.project.setDependencyVersion": "Resolve conflict...",
     "contributes.commands.maven.project.goToDefinition": "Go to Definition",
     "contributes.views.explorer.mavenProjects": "Maven",
     "contributes.viewsWelcome.mavenProjects.untrustedWorkspaces": "Advanced features (e.g. executing lifecycle phases and plugin goals) are disabled in Restricted Mode for security concern.\nPOM editing assistance (e.g. [add a dependency](command:maven.project.addDependency)) is still available.\nLearn more about [Workspace Trust](https://aka.ms/vscode-workspace-trust).\n[Manage Workspace Trust](command:workbench.action.manageTrust)",

--- a/src/explorer/model/Dependency.ts
+++ b/src/explorer/model/Dependency.ts
@@ -29,8 +29,11 @@ export class Dependency extends TreeNode implements ITreeItem {
 
     public getContextValue(): string {
         const root = <Dependency> this.root;
-        if(root.fullArtifactName === this.fullArtifactName) {
+        if (root.fullArtifactName === this.fullArtifactName) {
             return "rootDependency";
+        }
+        if (this.omittedStatus?.status === "conflict") {
+            return "conflictDependency";
         }
         return "Dependency";
     }

--- a/src/explorer/model/Dependency.ts
+++ b/src/explorer/model/Dependency.ts
@@ -28,6 +28,10 @@ export class Dependency extends TreeNode implements ITreeItem {
     }
 
     public getContextValue(): string {
+        const root = <Dependency> this.root;
+        if(root.fullArtifactName === this.fullArtifactName) {
+            return "rootDependency";
+        }
         return "Dependency";
     }
 


### PR DESCRIPTION
this pr makes three changes:

1. root dependencies do not have exclude command
2. only conflict dependencies have set-version command
3. change wording "set version to" to "resolve conflict"