### PR TITLE
fix goToDefinition: refine contextValue and when-clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -449,17 +449,17 @@
         },
         {
           "command": "maven.project.excludeDependency",
-          "when": "view == mavenProjects && viewItem =~ /^(?!.*?\\+root)/",
+          "when": "view == mavenProjects && viewItem =~ /maven:dependency(?!.*?\\b\\+root\\b)/",
           "group": "0-dependency@0"
         },
         {
           "command": "maven.project.setDependencyVersion",
-          "when": "view == mavenProjects && viewItem =~ /Dependency(?=.*?\\b\\+conflict\\b)/",
+          "when": "view == mavenProjects && viewItem =~ /maven:dependency(?=.*?\\b\\+conflict\\b)/",
           "group": "0-dependency@1"
         },
         {
           "command": "maven.project.goToDefinition",
-          "when": "view == mavenProjects && viewItem =~ /Dependency/",
+          "when": "view == mavenProjects && viewItem =~ /maven:dependency/",
           "group": "inline"
         },
         {

--- a/package.json
+++ b/package.json
@@ -449,17 +449,17 @@
         },
         {
           "command": "maven.project.excludeDependency",
-          "when": "view == mavenProjects && viewItem =~ /^(Dependency)|(conflictDependency)$/",
+          "when": "view == mavenProjects && viewItem =~ /^(?!.*?\\+root)/",
           "group": "0-dependency@0"
         },
         {
           "command": "maven.project.setDependencyVersion",
-          "when": "view == mavenProjects && viewItem == conflictDependency",
+          "when": "view == mavenProjects && viewItem =~ /Dependency(?=.*?\\b\\+conflict\\b)/",
           "group": "0-dependency@1"
         },
         {
           "command": "maven.project.goToDefinition",
-          "when": "view == mavenProjects && viewItem == Dependency",
+          "when": "view == mavenProjects && viewItem =~ /Dependency/",
           "group": "inline"
         },
         {

--- a/src/explorer/model/Dependency.ts
+++ b/src/explorer/model/Dependency.ts
@@ -29,13 +29,14 @@ export class Dependency extends TreeNode implements ITreeItem {
 
     public getContextValue(): string {
         const root = <Dependency> this.root;
+        let contextValue: string = "Dependency";
         if (root.fullArtifactName === this.fullArtifactName) {
-            return "rootDependency";
+            contextValue = `${contextValue}+root`;
         }
         if (this.omittedStatus?.status === "conflict") {
-            return "conflictDependency";
+           contextValue = `${contextValue}+conflict`;
         }
-        return "Dependency";
+        return contextValue;
     }
 
     public async getChildren(): Promise<Dependency[] | undefined> {

--- a/src/explorer/model/Dependency.ts
+++ b/src/explorer/model/Dependency.ts
@@ -29,7 +29,7 @@ export class Dependency extends TreeNode implements ITreeItem {
 
     public getContextValue(): string {
         const root = <Dependency> this.root;
-        let contextValue: string = "Dependency";
+        let contextValue: string = "maven:dependency";
         if (root.fullArtifactName === this.fullArtifactName) {
             contextValue = `${contextValue}+root`;
         }


### PR DESCRIPTION
this pr fixes the wrong entries of `goToDefinition` and refine context value and when-clause for future use.

format contextValue: `Dependency[+<type>]`
possible type: conflict, root

