### PR TITLE
support adding maven wrapper

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,8 +18,8 @@
                 ],
                 "background": {
                     "activeOnStart": true,
-                    "beginsPattern": "Compilation \\w+ starting…",
-                    "endsPattern": "Compilation\\s+finished"
+                    "beginsPattern": "\\w+",
+                    "endsPattern": "webpack .* compiled"
                 }
             },
             "isBackground": true,

--- a/package.json
+++ b/package.json
@@ -224,6 +224,11 @@
         "command": "maven.favorites",
         "title": "%contributes.commands.maven.favorites%",
         "category": "Maven"
+      },
+      {
+        "command": "maven.project.addWrapper",
+        "title": "%contributes.commands.maven.project.addWrapper%",
+        "category": "Maven"
       }
     ],
     "views": {
@@ -709,7 +714,7 @@
     "build-plugin": "node scripts/build-jdtls-ext.js",
     "compile": "tsc -p ./",
     "tslint": "tslint -t verbose --project tsconfig.json",
-    "watch": "webpack --mode development --watch --info-verbosity verbose",
+    "watch": "webpack --mode development --watch",
     "test": "npm run compile && node ./out/test/runTest.js",
     "webpack": "webpack --mode development"
   },

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,7 @@
     "contributes.commands.maven.project.setDependencyVersion": "Resolve Conflict...",
     "contributes.commands.maven.dependency.goToEffective": "Go to Effective Dependency",
     "contributes.commands.maven.project.goToDefinition": "Go to Definition",
+    "contributes.commands.maven.project.addWrapper": "Add Maven Wrapper",
     "contributes.views.explorer.mavenProjects": "Maven",
     "contributes.viewsWelcome.mavenProjects.untrustedWorkspaces": "Advanced features (e.g. executing lifecycle phases and plugin goals) are disabled in Restricted Mode for security concern.\nPOM editing assistance (e.g. [add a dependency](command:maven.project.addDependency)) is still available.\nLearn more about [Workspace Trust](https://aka.ms/vscode-workspace-trust).\n[Manage Workspace Trust](command:workbench.action.manageTrust)",
     "configuration.maven.excludedFolders": "Specifies file path pattern of folders to exclude while searching for Maven projects.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -19,6 +19,7 @@
     "contributes.commands.maven.project.excludeDependency": "删除依赖",
     "contributes.commands.maven.project.setDependencyVersion": "指定依赖版本为...",
     "contributes.commands.maven.dependency.goToEffective": "转到有效的依赖项",
+    "contributes.commands.maven.project.addWrapper": "添加 Maven Wrapper",
     "contributes.views.explorer.mavenProjects": "Maven",
     "contributes.viewsWelcome.mavenProjects.untrustedWorkspaces": "高级功能（例如：执行生命周期阶段与插件的目标命令）将会因为安全考量在限制模式中被停用。\nPOM编辑辅助功能（例如：[添加依赖]（command:maven.project.addDependency））仍可以使用。\n学习更多关于[工作区信任]（https://aka.ms/vscode-workspace-trust）\n[管理工作区信任]（command:workbench.action.manageTrust）",
     "configuration.maven.excludedFolders": "指定搜索 Maven 项目时要排除的文件夹。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -19,6 +19,7 @@
     "contributes.commands.maven.project.setDependencyVersion": "指定相依套件版本為...",
     "contributes.commands.maven.dependency.goToEffective": "移至有效的相依套件項",
     "contributes.commands.maven.project.goToDefinition": "移至定義",
+    "contributes.commands.maven.project.addWrapper": "Add Maven Wrapper",
     "contributes.views.explorer.mavenProjects": "Maven",
     "contributes.viewsWelcome.mavenProjects.untrustedWorkspaces": "進階功能 (例如: 執行生命週期階段與 Plugin 的目標命令) 將會因為安全考量在限制模式中被停用。\nPOM 編輯輔助功能 (例如: [新增相依套件](command:maven.project.addDependency)) 還是可以使用。\n學習更多關於 [工作區信任](https://aka.ms/vscode-workspace-trust)\n[管理工作區信任](command:workbench.action.manageTrust)",
     "configuration.maven.excludedFolders": "指定搜尋 Maven 專案時要排除的文件夾。",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { MavenProject } from "./explorer/model/MavenProject";
 import { PluginGoal } from "./explorer/model/PluginGoal";
 import { pluginInfoProvider } from "./explorer/pluginInfoProvider";
 import { addDependencyHandler } from "./handlers/addDependencyHandler";
+import { addWrapperHandler } from "./handlers/addWrapperHandler";
 import { debugHandler } from "./handlers/debugHandler";
 import { excludeDependencyHandler } from "./handlers/excludeDependencyHandler";
 import { goToEffectiveHandler } from "./handlers/goToEffectiveHandler";
@@ -151,6 +152,9 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     context.subscriptions.push(decorationProvider);
     // textDocument based output (e.g. effective-pom, dependencies)
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider("vscode-maven", contentProvider));
+
+    // add maven wrapper
+    registerCommand(context, "maven.project.addWrapper", () => addWrapperHandler());
 }
 
 function registerPomFileWatcher(context: vscode.ExtensionContext): void {

--- a/src/handlers/addWrapperHandler.ts
+++ b/src/handlers/addWrapperHandler.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import * as path from "path";
+import * as os from "os";
+import * as fse from "fs-extra";
+import { getPathToExtensionRoot } from "../utils/contextUtils";
+import { mavenDitributionExisting } from "../utils/requestUtils";
+
+const DEFAULT_MAVEN_VERSION: string = "3.6.3";
+const DEFAULT_WRAPPER_VERSION: string = "0.5.5";
+
+
+function wrapperProps(mavenVersion?: string, wrapperVersion?: string): string {
+    const vMaven = mavenVersion ?? DEFAULT_MAVEN_VERSION;
+    const vWrapper = wrapperVersion ?? DEFAULT_WRAPPER_VERSION;
+    return `distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${vMaven}/apache-maven-${vMaven}-bin.zip`
+        + os.EOL
+        + `wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/${vWrapper}/maven-wrapper-${vWrapper}.jar`
+        + os.EOL;
+}
+
+export async function addWrapperHandler() {
+    if (vscode.workspace.workspaceFolders === undefined || vscode.workspace.workspaceFolders.length === 0) {
+        vscode.window.showInformationMessage("Cancelled as no open workspace folder detected.");
+        return;
+    }
+
+    const targetWorkspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceFolders.length === 1 ? vscode.workspace.workspaceFolders[0]
+        : await vscode.window.showQuickPick(vscode.workspace.workspaceFolders.map(w => ({ ...w, label: w.name })));
+    if (targetWorkspaceFolder === undefined) {
+        return;
+    }
+
+    const targetFolder = targetWorkspaceFolder.uri.fsPath;
+    if (await fse.pathExists(path.join(targetFolder, "mvnw")) && await fse.pathExists(path.join(targetFolder, ".mvn"))) {
+        const BUTTON_PROCEED: string = "Proceed";
+        const choice = await vscode.window.showInformationMessage("Exisiting Maven wrapper detected, proceed to overwrite?",
+            BUTTON_PROCEED
+        );
+        if (choice !== BUTTON_PROCEED) {
+            return;
+        }
+    }
+
+    const mavenVersionValidator = (v: string) => {
+        if (v.match(/^\d+\.\d+\.\d+$/) === null) {
+            return "Invalid Maven Version.";
+        } else {
+            return null;
+        }
+    };
+
+    const mavenVersion = await vscode.window.showInputBox({
+        value: DEFAULT_MAVEN_VERSION,
+        prompt: "input Maven version",
+        validateInput: mavenVersionValidator
+    });
+
+    if (mavenVersion === undefined) {
+        return;
+    }
+
+    // verify if current version exists on Maven central
+    if (mavenVersion !== DEFAULT_MAVEN_VERSION /* skip check default version to boost */) {
+        const valid = await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: "Validating Maven Version..."
+        }, async (_progress) => {
+            return await mavenDitributionExisting(mavenVersion);
+        });
+
+        if (!valid) {
+            await vscode.window.showWarningMessage(`Maven distribution ${mavenVersion} is not available in Central Repository.`);
+            return;
+        }
+    }
+
+    await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "Adding Maven Wrapper..."
+    }, async (_progress) => {
+        const wrapperFolder: string = getPathToExtensionRoot("resources", "maven-wrapper");
+        await fse.copy(wrapperFolder, targetFolder);
+        // replace maven version
+        const propsFile = path.join(targetFolder, ".mvn", "wrapper", "maven-wrapper.properties");
+        const content = wrapperProps(mavenVersion);
+        await fse.writeFile(propsFile, content);
+    });
+}

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -5,7 +5,7 @@ import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as os from "os";
 import * as path from "path";
-import { Extension, ExtensionContext, extensions } from "vscode";
+import { ExtensionContext } from "vscode";
 import { mavenOutputChannel } from "../mavenOutputChannel";
 import { Utils } from "./Utils";
 
@@ -79,11 +79,7 @@ export function getPathToTempFolder(...args: string[]): string {
 }
 
 export function getPathToExtensionRoot(...args: string[]): string {
-    const ext: Extension<any> | undefined = extensions.getExtension(getExtensionId());
-    if (!ext) {
-        throw new Error("Cannot identify Maven extension.");
-    }
-    return path.join(ext.extensionPath, ...args);
+    return path.join(EXTENSION_CONTEXT.extensionPath , ...args);
 }
 
 export function getPathToWorkspaceStorage(...args: string[]): string | undefined {

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -97,6 +97,14 @@ async function httpsGet(urlString: string): Promise<string> {
     });
 }
 
+async function httpsGetStatusCode(uriString: string): Promise<number | undefined> {
+    return new Promise<number | undefined>((resolve, _reject) => {
+        https.get(url.parse(uriString), (res: http.IncomingMessage) => {
+            resolve(res.statusCode);
+        });
+    });
+}
+
 function toQueryString(params: { [key: string]: any }): string {
     return Object.keys(params).map(k => `${k}=${encodeURIComponent(params[k].toString())}`).join("&");
 }
@@ -104,4 +112,13 @@ function toQueryString(params: { [key: string]: any }): string {
 export async function fetchPluginMetadataXml(gid: string): Promise<string> {
     const metadataUrl = URL_MAVEN_CENTRAL_REPO + path.posix.join(...gid.split("."), MAVEN_METADATA_FILENAME);
     return await httpsGet(metadataUrl);
+}
+
+function mavenDistributionUrl(mavenVersion: string): string {
+    return `https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${mavenVersion}`;
+}
+
+export async function mavenDitributionExisting(mavenVersion: string): Promise<boolean> {
+    const statusCode = await httpsGetStatusCode(mavenDistributionUrl(mavenVersion));
+    return statusCode !== 404;
 }


### PR DESCRIPTION
See #735 

- Support to "Add maven wrapper".
  - currently only triggerred  from command palatte. 
  - it's added to workspace root folder. (we can discuss if it should be added per project in the future).

- BTW I updated tasks.json and build script, as new webpack-cli changes arguments and output format.
