### PR TITLE
allow external call to create project with predefined args

### DIFF
--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -18,14 +18,18 @@ const REMOTE_ARCHETYPE_CATALOG_URL: string = "https://repo.maven.apache.org/mave
 
 export namespace ArchetypeModule {
 
-    export async function createMavenProject(entry: Uri | undefined, _operationId: string): Promise<void> {
-        const targetFolder: string | undefined = entry?.fsPath ?? workspace.workspaceFolders?.[0]?.uri.fsPath;
-        // default metadata
+    export async function createMavenProject(entry: Uri | IProjectCreationMetadata | undefined, _operationId: string): Promise<void> {
         const metadata: IProjectCreationMetadata = {
-            targetFolder,
-            groupId: "com.example",
-            artifactId: "demo"
+            defaultGroupId: "com.example",
+            defaultArtifactId: "demo",
+            defaultTargetFolder: workspace.workspaceFolders?.[0]?.uri.fsPath
         };
+        if (entry instanceof Uri) {
+            metadata.defaultTargetFolder = entry.fsPath;
+        } else if (typeof entry === 'object') {
+            Object.assign(metadata, entry);
+        }
+
         const steps: IProjectCreationStep[] = [selectArchetypeStep, specifyArchetypeVersionStep, specifyGroupIdStep, specifyArtifactIdStep, specifyTargetFolderStep];
         const success: boolean = await runSteps(steps, metadata);
         if (success) {

--- a/src/archetype/createProject/SelectArchetypeStep.ts
+++ b/src/archetype/createProject/SelectArchetypeStep.ts
@@ -20,6 +20,9 @@ export class SelectArchetypeStep implements IProjectCreationStep {
     public readonly previousStep: undefined;
 
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
+        if (metadata.archetypeGroupId && metadata.archetypeArtifactId && metadata.archetypeVersion) {
+            return StepResult.NEXT;
+        }
 
         const disposables: Disposable[] = [];
         const specifyAchetypePromise = new Promise<StepResult>(async (resolve, _reject) => {

--- a/src/archetype/createProject/SpecifyArchetypeVersionStep.ts
+++ b/src/archetype/createProject/SpecifyArchetypeVersionStep.ts
@@ -8,6 +8,10 @@ export class SpecifyArchetypeVersionStep implements IProjectCreationStep {
     public previousStep?: IProjectCreationStep;
 
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
+        if (metadata.archetypeGroupId && metadata.archetypeArtifactId && metadata.archetypeVersion) {
+            return StepResult.NEXT;
+        }
+
         const disposables: Disposable[] = [];
         const specifyAchetypeVersionPromise = new Promise<StepResult>((resolve, reject) => {
             if (metadata.archetype?.versions === undefined) {

--- a/src/archetype/createProject/SpecifyArtifactIdStep.ts
+++ b/src/archetype/createProject/SpecifyArtifactIdStep.ts
@@ -8,13 +8,17 @@ export class SpecifyArtifactIdStep implements IProjectCreationStep {
     public previousStep?: IProjectCreationStep;
 
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
+        if (metadata.artifactId) {
+            return StepResult.NEXT;
+        }
+
         const disposables: Disposable[] = [];
         const quickInputPromise = new Promise<StepResult>((resolve, reject) => {
             const inputBox: InputBox = window.createInputBox();
             inputBox.title = "Create Maven Project";
             inputBox.placeholder = "e.g. demo";
             inputBox.prompt = "Input artifact Id of your project.";
-            inputBox.value = metadata.artifactId ?? "demo";
+            inputBox.value = metadata.defaultArtifactId ?? "demo";
             inputBox.ignoreFocusOut = true;
             if (this.previousStep) {
                 inputBox.buttons = [(QuickInputButtons.Back)];

--- a/src/archetype/createProject/SpecifyGroupIdStep.ts
+++ b/src/archetype/createProject/SpecifyGroupIdStep.ts
@@ -8,6 +8,9 @@ export class SpecifyGroupIdStep implements IProjectCreationStep {
     public previousStep?: IProjectCreationStep;
 
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
+        if (metadata.groupId) {
+            return StepResult.NEXT;
+        }
 
         const disposables: Disposable[] = [];
         const specifyGroupIdPromise = new Promise<StepResult>((resolve, reject) => {
@@ -15,7 +18,7 @@ export class SpecifyGroupIdStep implements IProjectCreationStep {
             inputBox.title = "Create Maven Project";
             inputBox.placeholder = "e.g. com.example";
             inputBox.prompt = "Input group Id of your project.";
-            inputBox.value = metadata.groupId ?? "com.example";
+            inputBox.value = metadata.defaultGroupId ?? "com.example";
             inputBox.ignoreFocusOut = true;
             if (this.previousStep) {
                 inputBox.buttons = [(QuickInputButtons.Back)];

--- a/src/archetype/createProject/SpecifyTargetFolderStep.ts
+++ b/src/archetype/createProject/SpecifyTargetFolderStep.ts
@@ -8,9 +8,13 @@ import { IProjectCreationMetadata, IProjectCreationStep, StepResult } from "./ty
 export class SpecifyTargetFolderStep implements IProjectCreationStep {
 
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
+        if (metadata.targetFolder) {
+            return StepResult.NEXT;
+        }
+
         // choose target folder.
         const result: Uri | undefined = await openDialogForFolder({
-            defaultUri: metadata.targetFolder !== undefined ? Uri.file(metadata.targetFolder) : undefined,
+            defaultUri: metadata.defaultTargetFolder !== undefined ? Uri.file(metadata.defaultTargetFolder) : undefined,
             openLabel: "Select Destination Folder"
         });
         const targetFolder: string | undefined = result?.fsPath;

--- a/src/archetype/createProject/types.ts
+++ b/src/archetype/createProject/types.ts
@@ -4,13 +4,17 @@
 import { Archetype } from "../Archetype";
 
 export interface IProjectCreationMetadata {
-    archetype?: Archetype; // temopary cached data between steps
+    archetype?: Archetype; // temporary cached data between steps, used to select versions
     archetypeArtifactId?: string;
     archetypeGroupId?: string;
     archetypeVersion?: string;
     groupId?: string;
     artifactId?: string;
     targetFolder?: string;
+    // fields for default values in quickbox
+    defaultGroupId?: string;
+    defaultArtifactId?: string;
+    defaultTargetFolder?: string;
 }
 
 export interface IProjectCreationStep {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { Progress, Uri } from "vscode";
 import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { ArchetypeModule } from "./archetype/ArchetypeModule";
+import { IProjectCreationMetadata } from "./archetype/createProject/types";
 import { codeActionProvider } from "./codeAction/codeActionProvider";
 import { ConflictResolver, conflictResolver } from "./codeAction/conflictResolver";
 import { completionProvider } from "./completion/completionProvider";
@@ -80,7 +81,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     registerCommandRequiringTrust(context, "maven.goal.custom", async (node: MavenProject) => await Utils.executeCustomGoal(node.pomPath));
     registerCommand(context, "maven.project.openPom", openPomHandler);
     // create project from archetype
-    registerCommand(context, "maven.archetype.generate", async (operationId: string, entry: Uri | undefined) => {
+    registerCommand(context, "maven.archetype.generate", async (operationId: string, entry: Uri | IProjectCreationMetadata | undefined) => {
         await ArchetypeModule.createMavenProject(entry, operationId);
     }, true);
     registerCommand(context, "maven.archetype.update", updateArchetypeCatalogHandler);


### PR DESCRIPTION
Can pass an `IProjectCreationMetadata` as argument to create Maven projects, which will avoid unnecessary user interactions. 
