### PR TITLE
execute mvn with maven.settingsFile

### DIFF
--- a/src/archetype/ArchetypeModule.ts
+++ b/src/archetype/ArchetypeModule.ts
@@ -76,7 +76,9 @@ export namespace ArchetypeModule {
         const mvnString: string = wrappedWithQuotes(await mavenTerminal.formattedPathForTerminal(mvnPath));
 
         const defaultArgs: string | undefined = Settings.Executable.options(metadata.targetFolder);
-        let commandLine: string = [mvnString, ...cmdArgs, defaultArgs].filter(Boolean).join(" ");
+        const mvnSettingsFile: string | undefined = Settings.getSettingsFilePath();
+        const mvnSettingsArg: string | undefined = mvnSettingsFile ? `-s "${await mavenTerminal.formattedPathForTerminal(mvnSettingsFile)}"` : undefined;
+        let commandLine: string = [mvnString, ...cmdArgs, defaultArgs, mvnSettingsArg].filter(Boolean).join(" ");
         const options: vscode.ShellExecutionOptions = { cwd };
         if (vscode.env.remoteName === undefined && process.platform === "win32") { // VS Code launched in Windows Desktop.
             options.shellQuoting = shellQuotes.cmd;

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -67,7 +67,7 @@ async function executeInBackground(mvnArgs: string, pomfile?: string): Promise<a
     const cwd: string | undefined = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, mvn, "..") : undefined;
     const userArgs: string | undefined = Settings.Executable.options(pomfile);
     const mvnSettingsFile: string | undefined = Settings.getSettingsFilePath();
-    const mvnSettingsArg: string | undefined = mvnSettingsFile ? `-s ${mvnSettingsFile}` : undefined;
+    const mvnSettingsArg: string | undefined = mvnSettingsFile ? `-s "${await mavenTerminal.formattedPathForTerminal(mvnSettingsFile)}"` : undefined;
     const matched: RegExpMatchArray | null = [mvnSettingsArg, mvnArgs, userArgs].filter(Boolean).join(" ").match(/(?:[^\s"]+|"[^"]*")+/g); // Split by space, but ignore spaces in quotes
     const args: string[] = matched !== null ? matched : [];
     if (pomfile) {
@@ -128,7 +128,7 @@ export async function executeInTerminal(options: {
     const mvnSettingsFile: string | undefined = Settings.getSettingsFilePath();
     const fullCommand: string = [
         mvnString,
-        mvnSettingsFile && `-s ${await mavenTerminal.formattedPathForTerminal(mvnSettingsFile)}`,
+        mvnSettingsFile && `-s "${await mavenTerminal.formattedPathForTerminal(mvnSettingsFile)}"`,
         command.trim(),
         pomfile && `-f "${await mavenTerminal.formattedPathForTerminal(pomfile)}"`,
         Settings.Executable.options(pomfile)

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -66,7 +66,9 @@ async function executeInBackground(mvnArgs: string, pomfile?: string): Promise<a
     const workspaceFolder: vscode.WorkspaceFolder | undefined = pomfile ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pomfile)) : undefined;
     const cwd: string | undefined = workspaceFolder ? path.resolve(workspaceFolder.uri.fsPath, mvn, "..") : undefined;
     const userArgs: string | undefined = Settings.Executable.options(pomfile);
-    const matched: RegExpMatchArray | null = [mvnArgs, userArgs].filter(Boolean).join(" ").match(/(?:[^\s"]+|"[^"]*")+/g); // Split by space, but ignore spaces in quotes
+    const mvnSettingsFile: string | undefined = Settings.getSettingsFilePath();
+    const mvnSettingsArg: string | undefined = mvnSettingsFile ? `-s ${mvnSettingsFile}` : undefined;
+    const matched: RegExpMatchArray | null = [mvnSettingsArg, mvnArgs, userArgs].filter(Boolean).join(" ").match(/(?:[^\s"]+|"[^"]*")+/g); // Split by space, but ignore spaces in quotes
     const args: string[] = matched !== null ? matched : [];
     if (pomfile) {
         args.push("-f", `"${pomfile}"`);
@@ -123,8 +125,10 @@ export async function executeInTerminal(options: {
     }
 
     const mvnString: string = wrappedWithQuotes(await mavenTerminal.formattedPathForTerminal(mvn));
+    const mvnSettingsFile: string | undefined = Settings.getSettingsFilePath();
     const fullCommand: string = [
         mvnString,
+        mvnSettingsFile && `-s ${await mavenTerminal.formattedPathForTerminal(mvnSettingsFile)}`,
         command.trim(),
         pomfile && `-f "${await mavenTerminal.formattedPathForTerminal(pomfile)}"`,
         Settings.Executable.options(pomfile)


### PR DESCRIPTION
Re-create PR #768 because it's accidentally closed.

Original description:
> Now that we have maven.settingsFile config, it seems natural to execute mvn with it (which I found out not.)
> Is there any concern not doing so.