### PR TITLE
fix icon of view-switching buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,13 +186,13 @@
         "command": "maven.view.flat",
         "title": "%contributes.commands.maven.view.flat%",
         "category": "Maven",
-        "icon": "$(list-tree)"
+        "icon": "$(list-flat)"
       },
       {
         "command": "maven.view.hierarchical",
         "title": "%contributes.commands.maven.view.hierarchical%",
         "category": "Maven",
-        "icon": "$(list-flat)"
+        "icon": "$(list-tree)"
       },
       {
         "command": "maven.project.addDependency",


### PR DESCRIPTION
Previously the icon shows "current" type of the tree view, i.e. 'flat' button was to switch to hierarchical view, 'tree' button was to switch to flat view.

