### PR TITLE
fix "Failed to find dependency" when findConflictRange

### DIFF
--- a/src/DiagnosticProvider.ts
+++ b/src/DiagnosticProvider.ts
@@ -89,8 +89,8 @@ class DiagnosticProvider {
         const projectNode: ElementNode = projectNodes[0];
         const dependenciesNode: ElementNode | undefined = projectNode.children?.find(node => node.tag === XmlTagName.Dependencies);
         const dependencyNode = dependenciesNode?.children?.find(node =>
-            node.children?.find(id => id.tag === XmlTagName.GroupId && project.fillProperties(id.text) === gid) !== undefined &&
-            node.children?.find(id => id.tag === XmlTagName.ArtifactId && project.fillProperties(id.text) === aid) !== undefined
+            node.children?.find(id => id.tag === XmlTagName.GroupId && id.text && project.fillProperties(id.text) === gid) !== undefined &&
+            node.children?.find(id => id.tag === XmlTagName.ArtifactId && id.text && project.fillProperties(id.text) === aid) !== undefined
         );
         if (dependencyNode === undefined) {
             throw new UserError("Failed to find dependency.");

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -228,7 +228,7 @@ export class MavenProject implements ITreeItem {
         }
     }
 
-    private fillProperties(rawName: string): string {
+    public fillProperties(rawName: string): string {
         const stringTemplatePattern: RegExp = /\$\{.*?\}/g;
         const matches: RegExpMatchArray | null = rawName.match(stringTemplatePattern);
         if (matches === null) {


### PR DESCRIPTION
Fix "Failed to find dependency" When there is a dependency conflict and the artifactId of dependency contains variables

Fixes #815 