### PR TITLE
add setting for format of project node name

### DIFF
--- a/package.json
+++ b/package.json
@@ -714,6 +714,19 @@
               "Add to Workspace",
               "None"
             ]
+          },
+          "maven.explorer.projectName": {
+            "default": "${project.name}",
+            "type": "string",
+            "scope": "window",
+            "description": "%configuration.maven.explorer.projectName%",
+            "enum": [
+              "${project.name}",
+              "${project.artifactId}",
+              "${project.artifactId}-${project.version}",
+              "${project.groupId}.${project.artifactId}",
+              "${project.groupId}.${project.artifactId}-${project.version}"
+            ]
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -40,5 +40,6 @@
     "configuration.maven.terminal.favorites.debug": "Whether to execute in debug mode.",
     "configuration.maven.settingsFile": "Specifies the absolute path of your maven configuration file, the default value is ~/.m2/settings.xml",
     "configuration.maven.dependency.enableConflictDiagnostics": "Specify whether to show diagnostics for conflict dependencies.",
-    "configuration.maven.projectOpenBehavior": "Default method of opening newly created project."
+    "configuration.maven.projectOpenBehavior": "Default method of opening newly created project.",
+    "configuration.maven.explorer.projectName": "Format of project node name shown in Maven explorer."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -40,5 +40,6 @@
     "configuration.maven.terminal.favorites.debug": "是否以调试模式运行。",
     "configuration.maven.settingsFile": "指定 maven 配置文件的绝对路径, 默认是 ~/.m2/settings.xml",
     "configuration.maven.dependency.enableConflictDiagnostics": "指定是否在 POM 文件中显示依赖冲突。",
-    "configuration.maven.projectOpenBehavior": "新建项目的默认打开方式"
+    "configuration.maven.projectOpenBehavior": "新建项目的默认打开方式。",
+    "configuration.maven.explorer.projectName": "Maven 项目名称的显示格式。"
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -40,5 +40,6 @@
     "configuration.maven.terminal.favorites.debug": "是否以偵錯模式運行。",
     "configuration.maven.settingsFile": "指定 maven 設定文件的絕對路徑，預設是 ~/.m2/settings.xml",
     "configuration.maven.dependency.enableConflictDiagnostics": "指定是否在 POM 文件中顯示相依套件衝突。",
-    "configuration.maven.projectOpenBehavior": "新建專案的預設打開方式"
+    "configuration.maven.projectOpenBehavior": "新建專案的預設打開方式。",
+    "configuration.maven.explorer.projectName": "Maven 專案名稱節點的格式。"
 }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -126,4 +126,26 @@ export namespace Settings {
             return {};
         }
     }
+
+    /**
+     * Get effective label of project node according to settings,
+     * filling ${project.groupId}, ${project.artifactId}, ${project.version}, ${project.name}
+     */
+    export function getExploreProjectName(project: {
+        pomPath?: string;
+        artifactId: string;
+        groupId: string;
+        version: string;
+        name: string;
+    }) {
+        const template = _getMavenSection<string>("explorer.projectName", project.pomPath);
+        if (!template) {
+            return undefined;
+        }
+
+        return template.replace("${project.name}", project.name)
+            .replace("${project.groupId}", project.groupId)
+            .replace("${project.artifactId}", project.artifactId)
+            .replace("${project.version}", project.version);
+    }
 }

--- a/src/explorer/model/MavenProject.ts
+++ b/src/explorer/model/MavenProject.ts
@@ -63,6 +63,10 @@ export class MavenProject implements ITreeItem {
         return this._pom?.project?.artifactId?.[0];
     }
 
+    public get version(): string {
+        return this._pom?.project?.version?.[0];
+    }
+
     public get id(): string {
         return `${this.groupId}:${this.artifactId}`;
     }
@@ -130,7 +134,7 @@ export class MavenProject implements ITreeItem {
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
         await this.parsePom();
-        const label: string = this.name ?? this.artifactId ?? "[Corrupted]";
+        const label = Settings.getExploreProjectName(this) ?? "[Corrupted]";
         const iconFile: string = this.packaging === "pom" ? "root.svg" : "project.svg";
         const treeItem: vscode.TreeItem = new vscode.TreeItem(label);
         treeItem.iconPath = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,7 +188,9 @@ function registerConfigChangeListener(context: vscode.ExtensionContext): void {
             mavenTerminal.dispose();
         }
         if (e.affectsConfiguration("maven.view")
-            || e.affectsConfiguration("maven.pomfile.globPattern")) {
+            || e.affectsConfiguration("maven.pomfile.globPattern")
+            || e.affectsConfiguration("maven.explorer.projectName")
+        ) {
             mavenExplorerProvider.refresh();
         }
         if (e.affectsConfiguration("maven.executable.preferMavenWrapper")) {


### PR DESCRIPTION
See https://github.com/microsoft/vscode-maven/issues/794#issuecomment-1177524076

Adding a new setting `maven.explorer.projectName` to specify format of project node name.