### PR TITLE
adopt fix in depgraph-maven-plugin:3.3.2

### DIFF
--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -44,7 +44,7 @@ export async function rawDependencyTree(pomPath: string): Promise<any> {
     const dependencyGraphPath: string = `${outputPath}.deps.txt`;
     const outputDirectory: string = path.dirname(dependencyGraphPath);
     const outputFileName: string = path.basename(dependencyGraphPath);
-    await executeInBackground(`-N com.github.ferstl:depgraph-maven-plugin:3.3.1:graph -DgraphFormat=text -DshowDuplicates -DshowConflicts -DshowVersions -DshowGroupIds -DoutputDirectory="${outputDirectory}" -DoutputFileName="${outputFileName}"`, pomPath);
+    await executeInBackground(`-N com.github.ferstl:depgraph-maven-plugin:3.3.2:graph -DgraphFormat=text -DshowDuplicates -DshowConflicts -DshowVersions -DshowGroupIds -DoutputDirectory="${outputDirectory}" -DoutputFileName="${outputFileName}"`, pomPath);
     return await readFileIfExists(path.join(outputDirectory, outputFileName));
 }
 


### PR DESCRIPTION
It's the maven plugin we used to generate dependencies information. Some bug fixes in v3.3.2.

See #852
