### PR TITLE
allow to add dependency without specifying version

### DIFF
--- a/src/handlers/dependency/addDependencyHandler.ts
+++ b/src/handlers/dependency/addDependencyHandler.ts
@@ -37,7 +37,7 @@ export async function addDependencyHandler(options?: any): Promise<void> {
     }
 
     // check if another extension has passed a dependency to add on its own
-    if (options && options.groupId && options.artifactId && options.version) {
+    if (options && options.groupId && options.artifactId) {
         await addDependency(pomPath, options.groupId, options.artifactId, options.version, options.packaging, options.classifier);
     }
     else {
@@ -68,7 +68,7 @@ export async function addDependencyHandler(options?: any): Promise<void> {
     }
 }
 
-async function addDependency(pomPath: string, gid: string, aid: string, version: string, dependencyType: string, classifier?: string): Promise<void> {
+async function addDependency(pomPath: string, gid: string, aid: string, version?: string, dependencyType?: string, classifier?: string): Promise<void> {
     // Find out <dependencies> node and insert content.
     const pomDocument = await vscode.window.showTextDocument(vscode.Uri.file(pomPath), { preserveFocus: true });
     const projectNodes: Element[] = getNodesByTag(pomDocument.document.getText(), XmlTagName.Project);
@@ -86,7 +86,7 @@ async function addDependency(pomPath: string, gid: string, aid: string, version:
     }
 }
 
-async function insertDependency(pomPath: string, targetNode: Element, gid: string, aid: string, version: string, dependencyType: string, classifier?: string): Promise<void> {
+async function insertDependency(pomPath: string, targetNode: Element, gid: string, aid: string, version?: string, dependencyType?: string, classifier?: string): Promise<void> {
     const currentDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(pomPath);
     const textEditor: vscode.TextEditor = await vscode.window.showTextDocument(currentDocument);
     const baseIndent: string = getIndentation(currentDocument, getInnerEndIndex(targetNode));

--- a/src/utils/editUtils.ts
+++ b/src/utils/editUtils.ts
@@ -56,7 +56,7 @@ export function getIndentation(document: vscode.TextDocument, offset: number): s
     ));
 }
 
-export function constructDependencyNode(options: { gid: string, aid: string, version: string, dtype?: string, classifier?: string, baseIndent: string, indent: string, eol: string }): string {
+export function constructDependencyNode(options: { gid: string, aid: string, version?: string, dtype?: string, classifier?: string, baseIndent: string, indent: string, eol: string }): string {
 
     const { gid, aid, version, dtype, classifier, baseIndent, indent, eol } = options;
 
@@ -66,8 +66,10 @@ export function constructDependencyNode(options: { gid: string, aid: string, ver
         "<dependency>",
         `${indent}<groupId>${gid}</groupId>`,
         `${indent}<artifactId>${aid}</artifactId>`,
-        `${indent}<version>${version}</version>`
     ];
+    if (version) {
+        builder.push(`${indent}<version>${version}</version>`);
+    }
 
     // add the packaging type if present and not the default
     if (dtype !== undefined && dtype !== "jar")
@@ -84,7 +86,7 @@ export function constructDependencyNode(options: { gid: string, aid: string, ver
     return builder.join(`${eol}${baseIndent}${indent}`);
 }
 
-export function constructDependenciesNode(options: { gid: string, aid: string, version: string, dtype?: string, classifier?: string, baseIndent: string, indent: string, eol: string }): string {
+export function constructDependenciesNode(options: { gid: string, aid: string, version?: string, dtype?: string, classifier?: string, baseIndent: string, indent: string, eol: string }): string {
 
     const { gid, aid, version, dtype, classifier, baseIndent, indent, eol } = options;
 


### PR DESCRIPTION
Change `version` as an optional parameter when calling `maven.project.addDependency` from external. 