### PR TITLE
sort artifacts by usage

### DIFF
--- a/src/handlers/dependency/addDependencyHandler.ts
+++ b/src/handlers/dependency/addDependencyHandler.ts
@@ -11,6 +11,7 @@ import { UserError } from "../../utils/errorUtils";
 import { getInnerEndIndex, getInnerStartIndex, getNodesByTag, XmlTagName } from "../../utils/lexerUtils";
 import { getArtifacts, IArtifactMetadata } from "../../utils/requestUtils";
 import { selectProjectIfNecessary } from "../../utils/uiUtils";
+import { getUsage } from "./artifactUsage";
 
 export async function addDependencyHandler(options?: any): Promise<void> {
     let pomPath: string;
@@ -58,7 +59,15 @@ export async function addDependencyHandler(options?: any): Promise<void> {
         }
 
         const selectedDoc: IArtifactMetadata | undefined = await vscode.window.showQuickPick<vscode.QuickPickItem & { value: IArtifactMetadata }>(
-            getArtifacts(keywordString.trim().split(/[-,. :]/)).then(artifacts => artifacts.map(artifact => ({ value: artifact, label: `$(package) ${artifact.a}`, description: artifact.g }))),
+            getArtifacts(keywordString.trim().split(/[-,. :]/))
+                .then(
+                    artifacts => artifacts.map(artifact => ({
+                        value: artifact,
+                        label: `$(package) ${artifact.a}`,
+                        description: artifact.g,
+                        usage: getUsage(`${artifact.g}:${artifact.a}`) // load usage data
+                    })).sort((a, b) => b.usage - a.usage) // from largest to smallest
+                ),
             {
                 placeHolder: "Select a dependency ...",
                 matchOnDescription: true

--- a/src/handlers/dependency/artifactUsage.ts
+++ b/src/handlers/dependency/artifactUsage.ts
@@ -22,9 +22,9 @@ function initialize() {
     const usageFilePath = getPathToExtensionRoot("resources", "IndexData", "ArtifactUsage.json");
     let raw;
     try {
-        raw = JSON.parse(readFileSync(usageFilePath).toString())    
+        raw = JSON.parse(readFileSync(usageFilePath).toString())
     } catch (error) {
-        console.log("Failed to load data from ArtifactUsage.json");
+        console.warn("Failed to load data from ArtifactUsage.json");
     }
 
     if (raw) {

--- a/src/handlers/dependency/artifactUsage.ts
+++ b/src/handlers/dependency/artifactUsage.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { readFileSync } from "fs";
+import { getPathToExtensionRoot } from "../../utils/contextUtils";
+
+/**
+ * Key: `gid:aid`
+ * Value: usage as integer
+ */
+let dict: Map<string, number>;
+
+export function getUsage(artifactId: string): number {
+    if (dict === undefined) {
+        initialize();
+    }
+
+    return dict.get(artifactId) ?? 0;
+}
+
+function initialize() {
+    const usageFilePath = getPathToExtensionRoot("resources", "IndexData", "ArtifactUsage.json");
+    let raw;
+    try {
+        raw = JSON.parse(readFileSync(usageFilePath).toString())    
+    } catch (error) {
+        console.log("Failed to load data from ArtifactUsage.json");
+    }
+
+    if (raw) {
+        dict = new Map();
+        for (const id of Object.keys(raw)) {
+            dict.set(id, raw[id]);
+        }
+    }
+}


### PR DESCRIPTION
Re-use artifact usage data, to sort candidates from largest to smallest.

![image](https://user-images.githubusercontent.com/2351748/192193738-3bebbfe1-d399-4f84-a2bb-5a36031c3166.png)
