### PR TITLE
Recommend to use CodeQL 3000 extension for Azure DevOps

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -19,31 +19,31 @@ jobs:
         toolMajorVersion: V2
         verboseOutput: true
         debugMode: false
-    - task: Semmle@1
-      displayName: Code QL for TS/JS
-      inputs:
-        sourceCodeDirectory: '$(Build.SourcesDirectory)'
-        language: 'tsandjs'
-        includeNodeModules: false
-        querySuite: 'Recommended'
-        timeout: '1800'
-        ram: '16384'
-        addProjectDirToScanningExclusionList: true
-    - task: Semmle@1
-      displayName: Code QL for Java
-      inputs:
-        sourceCodeDirectory: '$(Build.SourcesDirectory)/jdtls.ext'
-        language: 'java'
-        querySuite: 'Recommended'
-        timeout: '1800'
-        ram: '16384'
-        addProjectDirToScanningExclusionList: true
+    # - task: Semmle@1
+    #   displayName: Code QL for TS/JS
+    #   inputs:
+    #     sourceCodeDirectory: '$(Build.SourcesDirectory)'
+    #     language: 'tsandjs'
+    #     includeNodeModules: false
+    #     querySuite: 'Recommended'
+    #     timeout: '1800'
+    #     ram: '16384'
+    #     addProjectDirToScanningExclusionList: true
+    # - task: Semmle@1
+    #   displayName: Code QL for Java
+    #   inputs:
+    #     sourceCodeDirectory: '$(Build.SourcesDirectory)/jdtls.ext'
+    #     language: 'java'
+    #     querySuite: 'Recommended'
+    #     timeout: '1800'
+    #     ram: '16384'
+    #     addProjectDirToScanningExclusionList: true
     - task: PostAnalysis@1
       displayName: 'Post Analysis'
       inputs:
         CredScan: true
-        Semmle: true
-        SemmleBreakOn: 'Error'
+        # Semmle: true
+        # SemmleBreakOn: 'Error'
         ToolLogsNotFoundAction: 'Standard'
 
   - job: ci


### PR DESCRIPTION
"If you wish to enable CodeQL 3000 extension but you already onboarded to CodeQL previously though Guardian please first remove Guardian task where CodeQL is enabled."

In order to use the preferred CodeQL 3000 for ADO pipeline, I just comment the CodeQL Guardian task temporarily.