### PR TITLE
fix: add slf4j.api back

### DIFF
--- a/jdtls.ext/com.microsoft.java.maven.plugin/META-INF/MANIFEST.MF
+++ b/jdtls.ext/com.microsoft.java.maven.plugin/META-INF/MANIFEST.MF
@@ -21,7 +21,6 @@ Require-Bundle: com.google.guava,
  org.eclipse.text,
  org.eclipse.ltk.core.refactoring,
  com.google.gson,
- org.slf4j.api,
  org.eclipse.m2e.maven.runtime
 Bundle-ClassPath: .,
  lib/indexer-core-6.0.0.jar,
@@ -34,5 +33,6 @@ Bundle-ClassPath: .,
  lib/plexus-utils-3.2.1.jar,
  lib/maven-resolver-api-1.1.0.jar,
  lib/maven-resolver-util-1.1.0.jar,
- lib/aopalliance-1.0.jar
+ lib/aopalliance-1.0.jar,
+ lib/slf4j-api-1.7.10.jar
 Automatic-Module-Name: com.microsoft.java.maven

--- a/jdtls.ext/com.microsoft.java.maven.plugin/build.properties
+++ b/jdtls.ext/com.microsoft.java.maven.plugin/build.properties
@@ -14,4 +14,5 @@ bin.includes = META-INF/,\
                lib/plexus-utils-3.2.1.jar,\
                lib/maven-resolver-api-1.1.0.jar,\
                lib/maven-resolver-util-1.1.0.jar,\
-               lib/aopalliance-1.0.jar
+               lib/aopalliance-1.0.jar,\
+               lib/slf4j-api-1.7.10.jar

--- a/jdtls.ext/com.microsoft.java.maven.plugin/pom.xml
+++ b/jdtls.ext/com.microsoft.java.maven.plugin/pom.xml
@@ -103,6 +103,11 @@
 							<artifactId>aopalliance</artifactId>
 							<version>1.0</version>
 						</artifactItem>
+						<artifactItem>
+							<groupId>org.slf4j</groupId>
+							<artifactId>slf4j-api</artifactId>
+							<version>1.7.10</version>
+						</artifactItem>
 					</artifactItems>
 				</configuration>
 			</plugin>

--- a/jdtls.ext/target.target
+++ b/jdtls.ext/target.target
@@ -14,11 +14,9 @@
             <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.ibm.icu.base" version="58.2.0.v20170418-1837"/>
             <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
             <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
             <unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
-            <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
             <repository location="https://download.eclipse.org/tools/orbit/R-builds/R20200529191137/repository"/>
         </location>
     </locations>

--- a/test/projects/maven/src/main/java/com/mycompany/app/App.java
+++ b/test/projects/maven/src/main/java/com/mycompany/app/App.java
@@ -4,7 +4,7 @@ package com.mycompany.app;
  * Hello world!
  *
  */
-public class App 
+public class App
 {
     public static void main( String[] args )
     {


### PR DESCRIPTION
`slf4j.api` is required by `maven-core`. the bundle is no longer required by m2e, thus we add it back manually to work it around.