### PR TITLE
Reload pom contents as needed before finding parent POMs

### DIFF
--- a/src/archetype/createProject/SelectParentPomStep.ts
+++ b/src/archetype/createProject/SelectParentPomStep.ts
@@ -19,7 +19,16 @@ export class SelectParentPom implements IProjectCreationStep {
             }
         ];
         MavenProjectManager.projects
-            .filter(project => project.artifactId && project.pomPath && pathExistsSync(project.pomPath))
+            .filter(project => project.pomPath && pathExistsSync(project.pomPath))
+            .map(project => {
+                if (!project.artifactId) {
+                    // reload pom contents
+                    project.parsePom();
+                }
+
+                return project;
+            })
+            .filter(project => project.artifactId && project.groupId)
             .sort((a, b) => a.pomPath.length - b.pomPath.length)
             .forEach(project => {
                 items.push({

--- a/src/project/MavenProjectManager.ts
+++ b/src/project/MavenProjectManager.ts
@@ -59,7 +59,9 @@ export class MavenProjectManager {
     }
 
     public static add(pomPath: string): void {
-        MavenProjectManager.getInstance()._projectMap.set(pomPath, new MavenProject(pomPath));
+        const newProject = new MavenProject(pomPath);
+        newProject.parsePom();
+        MavenProjectManager.getInstance()._projectMap.set(pomPath, newProject);
     }
 
     public static remove(pomPath: string): void {


### PR DESCRIPTION
When selecting the parent pom list during "New Module", sometimes the newly added module is not recognized. This is because the maven model cache didn't store the pom contents yet and leave the artifactId is undefined. 