### PR TITLE
enable maven executable path override on workspace level

### DIFF
--- a/package.json
+++ b/package.json
@@ -659,7 +659,7 @@
             "type": "string",
             "default": "",
             "description": "%configuration.maven.executable.path%",
-            "scope": "machine"
+            "scope": "machine-overridable"
           },
           "maven.executable.options": {
             "anyOf": [


### PR DESCRIPTION
fix #1055 