### PR TITLE
Add workspace-level Maven settings file override

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -47,6 +47,10 @@ export class Settings {
         return _getMavenSection<string>("settingsFile");
     }
 
+    public static getWorkspaceSettingsPath(): string | undefined {
+        return workspace.getConfiguration().get("maven.settingsFile") ?? undefined;
+    }
+
     public static External = class {
         public static javaHome(): string | undefined {
             return workspace.getConfiguration("java").get<string>("home");

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -40,8 +40,14 @@ export async function loadPackageInfo(context: ExtensionContext): Promise<void> 
 export async function loadMavenSettingsFilePath(): Promise<void> {
     // find Maven Local Repository
     try {
-        let userSettingsPath: string | undefined = Settings.getSettingsFilePath();
+        // First check project-specific settings
+        let userSettingsPath: string | undefined = Settings.getWorkspaceSettingsPath();
         if (!userSettingsPath) {
+            // Then check user settings
+            userSettingsPath = Settings.getSettingsFilePath();
+        }
+        if (!userSettingsPath) {
+            // Finally fallback to default user settings path
             userSettingsPath = path.join(os.homedir(), ".m2", "settings.xml");
         }
         const userSettings: unknown = await Utils.parseXmlFile(userSettingsPath);


### PR DESCRIPTION
Enhances Maven settings file resolution by adding workspace-level configuration support. The system now checks for settings in the following order:

1. Workspace/project-specific settings
2. User-level settings
3. Default .m2/settings.xml location

This allows for more flexible Maven configuration management per project while maintaining backward compatibility.