### PR TITLE
Add workspace-level Maven settings file override

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -47,6 +47,10 @@ export class Settings {
         return _getMavenSection<string>("settingsFile");
     }
 
+    public static getWorkspaceSettingsPath(): string | undefined {
+        return workspace.getConfiguration().get("maven.settingsFile") ?? undefined;
+    }
+
     public static External = class {
         public static javaHome(): string | undefined {
             return workspace.getConfiguration("java").get<string>("home");

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -44,11 +44,13 @@ export class Settings {
     }
 
     public static getSettingsFilePath(): string | undefined {
-        return _getMavenSection<string>("settingsFile");
-    }
-
-    public static getWorkspaceSettingsPath(): string | undefined {
-        return workspace.getConfiguration().get("maven.settingsFile") ?? undefined;
+        const workspaceFolders = workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            return undefined;
+        }
+        const workspaceUri = workspaceFolders[0].uri;
+        const settingsFile = workspace.getConfiguration("maven", workspaceUri).get<string>("settingsFile");
+        return settingsFile ? settingsFile :_getMavenSection<string>("settingsFile");
     }
 
     public static External = class {

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -40,8 +40,14 @@ export async function loadPackageInfo(context: ExtensionContext): Promise<void> 
 export async function loadMavenSettingsFilePath(): Promise<void> {
     // find Maven Local Repository
     try {
-        let userSettingsPath: string | undefined = Settings.getSettingsFilePath();
+        // First check project-specific settings
+        let userSettingsPath: string | undefined = Settings.getWorkspaceSettingsPath();
         if (!userSettingsPath) {
+            // Then check user settings
+            userSettingsPath = Settings.getSettingsFilePath();
+        }
+        if (!userSettingsPath) {
+            // Finally fallback to default user settings path
             userSettingsPath = path.join(os.homedir(), ".m2", "settings.xml");
         }
         const userSettings: unknown = await Utils.parseXmlFile(userSettingsPath);

--- a/src/utils/contextUtils.ts
+++ b/src/utils/contextUtils.ts
@@ -41,11 +41,7 @@ export async function loadMavenSettingsFilePath(): Promise<void> {
     // find Maven Local Repository
     try {
         // First check project-specific settings
-        let userSettingsPath: string | undefined = Settings.getWorkspaceSettingsPath();
-        if (!userSettingsPath) {
-            // Then check user settings
-            userSettingsPath = Settings.getSettingsFilePath();
-        }
+        let userSettingsPath: string | undefined = Settings.getSettingsFilePath();
         if (!userSettingsPath) {
             // Finally fallback to default user settings path
             userSettingsPath = path.join(os.homedir(), ".m2", "settings.xml");


### PR DESCRIPTION
Enhances Maven settings file resolution by adding workspace-level configuration support. The system now checks for settings in the following order:

Workspace/project-specific settings
User-level settings
Default .m2/settings.xml location
This allows for more flexible Maven configuration management per project while maintaining backward compatibility.