### PR TITLE
fix: revert problem matchers to fix the execute in terminal file usage issue

### DIFF
--- a/src/mavenTerminal.ts
+++ b/src/mavenTerminal.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { mavenOutputChannel } from "./mavenOutputChannel";
 import { Settings } from "./Settings";
+import { executeCommand } from "./utils/cpUtils";
 import { mavenProblemMatcher } from "./mavenProblemMatcher";
 
 export interface ITerminalOptions {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -183,7 +183,7 @@ export class Utils {
         const inputGoals: string | undefined = goal || await window.showInputBox({ placeHolder: "e.g. clean package -DskipTests", ignoreFocusOut: true });
         const trimmedGoals: string | undefined = inputGoals ? inputGoals.trim() : undefined;
         if (trimmedGoals) {
-            await executeInTerminal({ command: trimmedGoals, pomfile: pomPath, skipProblemMatching: true });
+            await executeInTerminal({ command: trimmedGoals, pomfile: pomPath });
         }
     }
 

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -138,9 +138,8 @@ export async function executeInTerminal(options: {
     cwd?: string;
     env?: { [key: string]: string };
     terminalName?: string;
-    skipProblemMatching?: boolean;
 }): Promise<vscode.Terminal | undefined> {
-    const { command, mvnPath, pomfile, cwd, env, terminalName, skipProblemMatching } = options;
+    const { command, mvnPath, pomfile, cwd, env, terminalName } = options;
     const workspaceFolder: vscode.WorkspaceFolder | undefined = pomfile ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pomfile)) : undefined;
     const mvn: string | undefined = mvnPath ? mvnPath : await getMaven(pomfile);
     if (mvn === undefined) {


### PR DESCRIPTION
this PR is going to fix https://github.com/microsoft/vscode-maven/issues/1119
Issue: Introduced by problemmatch; problemmatcher runs mvn twice in the background, causing process lock on Windows.
Short-term fix: Revert problem matcher changes and consider using VS Code Terminal API for implementation.

```
executeInTerminal()
├── mavenTerminal.runInTerminal()
│   ├── sendText()                 ← 1st exec
│   └── captureMavenOutput()       ← 2nd exec
└── executeInBackground()          ← 3rd exec
```