### PR TITLE
Bump version to 0.45.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the "vscode-maven" extension will be documented in this file.
 
+## 0.45.2
+### Fixed
+- Fix terminal handler to also setup custom environment variables before calling Maven [#1141](https://github.com/microsoft/vscode-maven/pull/1141)
+- Maven dependencies fail to generate dependency graph [#1131](https://github.com/microsoft/vscode-maven/pull/1131)
+
 ## 0.45.1
 ### Fixed
 - revert problem matchers to fix the execute in terminal file usage issue [#1119](https://github.com/microsoft/vscode-maven/issues/1119)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-maven",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-maven",
-      "version": "0.45.1",
+      "version": "0.45.2",
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-maven",
   "displayName": "Maven for Java",
   "description": "%description%",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "icon": "resources/logo.png",
   "publisher": "vscjava",
   "preview": false,


### PR DESCRIPTION
Bump version to 0.45.2 and update CHANGELOG.

## Changes included in this release

### Fixed
- Fix terminal handler to also setup custom environment variables before calling Maven (#1141)
- Maven dependencies fail to generate dependency graph (#1131)