### PR TITLE
Improve workspace configuration handling for Maven executable settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "restrictedConfigurations": [
+        "maven.executable.path",
         "maven.executable.options",
-        "maven.terminal.customEnv"
+        "maven.executable.preferMavenWrapper",
+        "maven.terminal.customEnv",
+        "maven.terminal.favorites",
+        "maven.pomfile.autoUpdateEffectivePOM"
       ]
     }
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     DEFAULT_MAVEN_LIFECYCLES.forEach((goal: string) => {
         registerCommandRequiringTrust(context, `maven.goal.${goal}`, async (node: MavenProject) => executeInTerminal({ command: goal, pomfile: node.pomPath }));
     });
-    registerCommandRequiringTrust(context, "maven.explorer.refresh", async (item: ITreeItem) => {
+    registerCommand(context, "maven.explorer.refresh", async (item: ITreeItem) => {
         item?.refresh ? item.refresh() : MavenExplorerProvider.getInstance().refresh(item);
     });
     registerCommandRequiringTrust(context, "maven.project.effectivePom", async (projectOrUri: Uri | MavenProject) => await Utils.showEffectivePom(projectOrUri));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ async function doActivate(_operationId: string, context: vscode.ExtensionContext
     DEFAULT_MAVEN_LIFECYCLES.forEach((goal: string) => {
         registerCommandRequiringTrust(context, `maven.goal.${goal}`, async (node: MavenProject) => executeInTerminal({ command: goal, pomfile: node.pomPath }));
     });
-    registerCommand(context, "maven.explorer.refresh", async (item: ITreeItem) => {
+    registerCommandRequiringTrust(context, "maven.explorer.refresh", async (item: ITreeItem) => {
         item?.refresh ? item.refresh() : MavenExplorerProvider.getInstance().refresh(item);
     });
     registerCommandRequiringTrust(context, "maven.project.effectivePom", async (projectOrUri: Uri | MavenProject) => await Utils.showEffectivePom(projectOrUri));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,7 +197,7 @@ function registerPomFileWatcher(context: vscode.ExtensionContext): void {
             contentProvider.invalidate(dependenciesContentUri(project.pomPath));
 
             await project.refresh();
-            if (Settings.Pomfile.autoUpdateEffectivePOM()) {
+            if (vscode.workspace.isTrusted && Settings.Pomfile.autoUpdateEffectivePOM()) {
                 taskExecutor.execute(async () => {
                     await project.refreshEffectivePom();
                     MavenExplorerProvider.getInstance().refresh(project);

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -182,11 +182,16 @@ export async function getMaven(pomPath?: string): Promise<string | undefined> {
     if (mvnPathFromSettings) {
         // expand tilde to deal with ~/path-to-mvn
         const expandedPath: string = expandHome(mvnPathFromSettings);
-        if (await isExecutablePathSafe(expandedPath)) {
+        const safetyResult: "safe" | "use-default" | "abort" = await checkExecutablePathSafety(expandedPath);
+        if (safetyResult === "safe") {
             return expandedPath;
         }
-        // User declined the suspicious path — skip wrapper (also potentially attacker-controlled)
-        // and fall through directly to system-installed Maven
+        if (safetyResult === "abort") {
+            // User chose Open Settings or dismissed — abort the operation
+            return undefined;
+        }
+        // "use-default": User explicitly chose to use default Maven — skip wrapper
+        // (also potentially attacker-controlled) and fall through to system Maven
         mavenOutputChannel.appendLine(`Configured Maven path "${expandedPath}" was declined. Falling back to system Maven.`);
         return await defaultMavenExecutable();
     }
@@ -202,7 +207,7 @@ export async function getMaven(pomPath?: string): Promise<string | undefined> {
     return await defaultMavenExecutable();
 }
 
-// Set of executable paths the user has explicitly confirmed as safe during this session
+// Set of canonical executable paths the user has explicitly confirmed as safe during this session
 const confirmedExecutablePaths: Set<string> = new Set();
 
 /**
@@ -234,40 +239,61 @@ function getEffectiveExecutablePath(resourceOrFilepath?: vscode.Uri | string): s
 }
 
 /**
+ * Canonicalizes a path by resolving symlinks/junctions via fs.realpath.
+ * Falls back to the original path if the file doesn't exist yet.
+ */
+async function canonicalizePath(filePath: string): Promise<string> {
+    try {
+        return await fse.realpath(filePath);
+    } catch {
+        return filePath;
+    }
+}
+
+/**
  * Validates whether a configured Maven executable path is safe to use.
  * Rejects relative paths and paths that resolve inside a workspace folder,
  * as these could be attacker-controlled binaries placed in a malicious workspace.
  * Prompts the user for confirmation and caches their decision for the session.
+ *
+ * @returns "safe" if the path is allowed, "use-default" if the user chose to fall back,
+ *          "abort" if the user dismissed the dialog or chose to open settings.
  */
-async function isExecutablePathSafe(executablePath: string): Promise<boolean> {
-    if (confirmedExecutablePaths.has(executablePath)) {
-        return true;
-    }
-
+async function checkExecutablePathSafety(executablePath: string): Promise<"safe" | "use-default" | "abort"> {
     // Relative paths are inherently suspicious — a real Maven installation
     // always has an absolute path (e.g. /usr/local/bin/mvn, C:\maven\bin\mvn.cmd)
     if (!path.isAbsolute(executablePath)) {
-        return await promptForExecutableConfirmation(executablePath);
+        if (confirmedExecutablePaths.has(executablePath)) {
+            return "safe";
+        }
+        const result = await promptForExecutableConfirmation(executablePath);
+        if (result === "safe") {
+            confirmedExecutablePaths.add(executablePath);
+        }
+        return result;
     }
 
-    // Canonicalize the path to resolve symlinks/junctions before checking containment
-    let canonicalPath: string;
-    try {
-        canonicalPath = await fse.realpath(executablePath);
-    } catch {
-        // If realpath fails (file doesn't exist yet), use the original path
-        canonicalPath = executablePath;
+    // Canonicalize the path to resolve symlinks/junctions before checking
+    const canonicalPath: string = await canonicalizePath(executablePath);
+
+    // Check the cache using the canonical path
+    if (confirmedExecutablePaths.has(canonicalPath)) {
+        return "safe";
     }
 
     // Absolute paths inside a workspace folder are also suspicious
     if (vscode.workspace.getWorkspaceFolder(vscode.Uri.file(canonicalPath)) !== undefined) {
-        return await promptForExecutableConfirmation(executablePath);
+        const result = await promptForExecutableConfirmation(executablePath);
+        if (result === "safe") {
+            confirmedExecutablePaths.add(canonicalPath);
+        }
+        return result;
     }
 
-    return true;
+    return "safe";
 }
 
-async function promptForExecutableConfirmation(executablePath: string): Promise<boolean> {
+async function promptForExecutableConfirmation(executablePath: string): Promise<"safe" | "use-default" | "abort"> {
     const USE_IT = "Allow";
     const USE_DEFAULT = "Use Default Maven";
     const OPEN_SETTINGS = "Open Settings";
@@ -279,13 +305,16 @@ async function promptForExecutableConfirmation(executablePath: string): Promise<
         OPEN_SETTINGS
     );
     if (choice === USE_IT) {
-        confirmedExecutablePaths.add(executablePath);
-        return true;
+        return "safe";
+    }
+    if (choice === USE_DEFAULT) {
+        return "use-default";
     }
     if (choice === OPEN_SETTINGS) {
         await vscode.commands.executeCommand("workbench.action.openSettings", "maven.executable.path");
     }
-    return false;
+    // Esc or Open Settings → abort the current operation
+    return "abort";
 }
 
 export function getEmbeddedMavenWrapper(): string {

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -178,14 +178,17 @@ export async function executeInTerminal(options: {
 }
 
 export async function getMaven(pomPath?: string): Promise<string | undefined> {
-    const mvnPathFromSettings: string | undefined = Settings.Executable.path(pomPath);
-    if (mvnPathFromSettings && vscode.workspace.isTrusted) {
+    const mvnPathFromSettings: string | undefined = getEffectiveExecutablePath(pomPath);
+    if (mvnPathFromSettings) {
         // expand tilde to deal with ~/path-to-mvn
         const expandedPath: string = expandHome(mvnPathFromSettings);
         if (await isExecutablePathSafe(expandedPath)) {
             return expandedPath;
         }
-        // Unsafe path (relative or inside workspace) — fall through to wrapper/default fallback
+        // User declined the suspicious path — skip wrapper (also potentially attacker-controlled)
+        // and fall through directly to system-installed Maven
+        mavenOutputChannel.appendLine(`Configured Maven path "${expandedPath}" was declined. Falling back to system Maven.`);
+        return await defaultMavenExecutable();
     }
 
     const preferMavenWrapper: boolean = Settings.Executable.preferMavenWrapper(pomPath);
@@ -201,6 +204,34 @@ export async function getMaven(pomPath?: string): Promise<string | undefined> {
 
 // Set of executable paths the user has explicitly confirmed as safe during this session
 const confirmedExecutablePaths: Set<string> = new Set();
+
+/**
+ * Returns the effective maven.executable.path, filtering out workspace-level
+ * overrides when the workspace is not trusted. User/machine-level (global)
+ * settings are always honored regardless of trust state.
+ */
+function getEffectiveExecutablePath(resourceOrFilepath?: vscode.Uri | string): string | undefined {
+    let resource: vscode.Uri | undefined;
+    if (typeof resourceOrFilepath === "string") {
+        resource = vscode.Uri.file(resourceOrFilepath);
+    } else {
+        resource = resourceOrFilepath;
+    }
+    const config = vscode.workspace.getConfiguration("maven", resource);
+    const inspection = config.inspect<string>("executable.path");
+    if (!inspection) {
+        return undefined;
+    }
+
+    if (vscode.workspace.isTrusted) {
+        // Trusted workspace: return the fully resolved value (workspace overrides allowed)
+        return config.get<string>("executable.path") || undefined;
+    }
+
+    // Untrusted workspace: only honor user/machine-level (global) settings,
+    // ignore workspaceValue and workspaceFolderValue
+    return inspection.globalValue ?? inspection.defaultValue ?? undefined;
+}
 
 /**
  * Validates whether a configured Maven executable path is safe to use.
@@ -219,8 +250,17 @@ async function isExecutablePathSafe(executablePath: string): Promise<boolean> {
         return await promptForExecutableConfirmation(executablePath);
     }
 
+    // Canonicalize the path to resolve symlinks/junctions before checking containment
+    let canonicalPath: string;
+    try {
+        canonicalPath = await fse.realpath(executablePath);
+    } catch {
+        // If realpath fails (file doesn't exist yet), use the original path
+        canonicalPath = executablePath;
+    }
+
     // Absolute paths inside a workspace folder are also suspicious
-    if (vscode.workspace.getWorkspaceFolder(vscode.Uri.file(executablePath)) !== undefined) {
+    if (vscode.workspace.getWorkspaceFolder(vscode.Uri.file(canonicalPath)) !== undefined) {
         return await promptForExecutableConfirmation(executablePath);
     }
 
@@ -230,15 +270,20 @@ async function isExecutablePathSafe(executablePath: string): Promise<boolean> {
 async function promptForExecutableConfirmation(executablePath: string): Promise<boolean> {
     const USE_IT = "Allow";
     const USE_DEFAULT = "Use Default Maven";
+    const OPEN_SETTINGS = "Open Settings";
     const choice: string | undefined = await vscode.window.showWarningMessage(
         `The configured Maven executable path "${executablePath}" points to a location inside the workspace or is a relative path. Using it could be a security risk. Do you want to proceed?`,
         { modal: true },
         USE_IT,
-        USE_DEFAULT
+        USE_DEFAULT,
+        OPEN_SETTINGS
     );
     if (choice === USE_IT) {
         confirmedExecutablePaths.add(executablePath);
         return true;
+    }
+    if (choice === OPEN_SETTINGS) {
+        await vscode.commands.executeCommand("workbench.action.openSettings", "maven.executable.path");
     }
     return false;
 }

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -185,8 +185,7 @@ export async function getMaven(pomPath?: string): Promise<string | undefined> {
         if (await isExecutablePathSafe(expandedPath)) {
             return expandedPath;
         }
-        // Unsafe path (relative or inside workspace) — fall through to defaults
-        return await defaultMavenExecutable();
+        // Unsafe path (relative or inside workspace) — fall through to wrapper/default fallback
     }
 
     const preferMavenWrapper: boolean = Settings.Executable.preferMavenWrapper(pomPath);
@@ -221,16 +220,8 @@ async function isExecutablePathSafe(executablePath: string): Promise<boolean> {
     }
 
     // Absolute paths inside a workspace folder are also suspicious
-    const normalizedExecPath: string = path.normalize(executablePath);
-    const workspaceFolders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? [];
-    for (const folder of workspaceFolders) {
-        const folderPath: string = path.normalize(folder.uri.fsPath);
-        // Case-insensitive comparison on Windows
-        const execLower: string = normalizedExecPath.toLowerCase();
-        const folderLower: string = folderPath.toLowerCase();
-        if (execLower.startsWith(folderLower + path.sep) || execLower === folderLower) {
-            return await promptForExecutableConfirmation(executablePath);
-        }
+    if (vscode.workspace.getWorkspaceFolder(vscode.Uri.file(executablePath)) !== undefined) {
+        return await promptForExecutableConfirmation(executablePath);
     }
 
     return true;

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -179,9 +179,14 @@ export async function executeInTerminal(options: {
 
 export async function getMaven(pomPath?: string): Promise<string | undefined> {
     const mvnPathFromSettings: string | undefined = Settings.Executable.path(pomPath);
-    if (mvnPathFromSettings) {
+    if (mvnPathFromSettings && vscode.workspace.isTrusted) {
         // expand tilde to deal with ~/path-to-mvn
-        return expandHome(mvnPathFromSettings);
+        const expandedPath: string = expandHome(mvnPathFromSettings);
+        if (await isExecutablePathSafe(expandedPath)) {
+            return expandedPath;
+        }
+        // Unsafe path (relative or inside workspace) — fall through to defaults
+        return await defaultMavenExecutable();
     }
 
     const preferMavenWrapper: boolean = Settings.Executable.preferMavenWrapper(pomPath);
@@ -193,6 +198,58 @@ export async function getMaven(pomPath?: string): Promise<string | undefined> {
     }
 
     return await defaultMavenExecutable();
+}
+
+// Set of executable paths the user has explicitly confirmed as safe during this session
+const confirmedExecutablePaths: Set<string> = new Set();
+
+/**
+ * Validates whether a configured Maven executable path is safe to use.
+ * Rejects relative paths and paths that resolve inside a workspace folder,
+ * as these could be attacker-controlled binaries placed in a malicious workspace.
+ * Prompts the user for confirmation and caches their decision for the session.
+ */
+async function isExecutablePathSafe(executablePath: string): Promise<boolean> {
+    if (confirmedExecutablePaths.has(executablePath)) {
+        return true;
+    }
+
+    // Relative paths are inherently suspicious — a real Maven installation
+    // always has an absolute path (e.g. /usr/local/bin/mvn, C:\maven\bin\mvn.cmd)
+    if (!path.isAbsolute(executablePath)) {
+        return await promptForExecutableConfirmation(executablePath);
+    }
+
+    // Absolute paths inside a workspace folder are also suspicious
+    const normalizedExecPath: string = path.normalize(executablePath);
+    const workspaceFolders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? [];
+    for (const folder of workspaceFolders) {
+        const folderPath: string = path.normalize(folder.uri.fsPath);
+        // Case-insensitive comparison on Windows
+        const execLower: string = normalizedExecPath.toLowerCase();
+        const folderLower: string = folderPath.toLowerCase();
+        if (execLower.startsWith(folderLower + path.sep) || execLower === folderLower) {
+            return await promptForExecutableConfirmation(executablePath);
+        }
+    }
+
+    return true;
+}
+
+async function promptForExecutableConfirmation(executablePath: string): Promise<boolean> {
+    const USE_IT = "Allow";
+    const USE_DEFAULT = "Use Default Maven";
+    const choice: string | undefined = await vscode.window.showWarningMessage(
+        `The configured Maven executable path "${executablePath}" points to a location inside the workspace or is a relative path. Using it could be a security risk. Do you want to proceed?`,
+        { modal: true },
+        USE_IT,
+        USE_DEFAULT
+    );
+    if (choice === USE_IT) {
+        confirmedExecutablePaths.add(executablePath);
+        return true;
+    }
+    return false;
 }
 
 export function getEmbeddedMavenWrapper(): string {


### PR DESCRIPTION
Expanded the set of workspace-scoped settings gated by `restrictedConfigurations` to ensure consistent behavior across different workspace trust states.

Changes:
- Added `maven.executable.path`, `maven.executable.preferMavenWrapper`, `maven.terminal.favorites`, and `maven.pomfile.autoUpdateEffectivePOM` to `restrictedConfigurations`
- Added validation for the configured Maven executable path before use in `getMaven()`
- Added workspace trust check before auto-updating effective POM on file change