### PR TITLE
Update CI actions to v4 to fix macOS ARM64 runner failure

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Build Environment
       run: |
@@ -21,12 +21,13 @@ jobs:
         sudo /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         sleep 3
     - name: Set up JDK 21
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
+        distribution: 'adopt'
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 20
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -12,15 +12,16 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
+        distribution: 'adopt'
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 20
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,15 +12,16 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
+        distribution: 'adopt'
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 20
 


### PR DESCRIPTION
The macOS CI job fails because `actions/setup-java@v1` installs an x64 JDK on the ARM64 `macos-latest` runner, which can't execute the binary:

```
Error: JAVA_HOME is not defined correctly.
  We cannot execute /Users/runner/hostedtoolcache/jdk/21.0.11/x64/bin/java
```

Updates all three CI workflows (linux, macOS, windows):
- `actions/checkout` v2 → v4
- `actions/setup-java` v1 → v4 (with `distribution: adopt` — required by v4, and correctly resolves architecture)
- `actions/setup-node` v2 → v4

This also resolves the Node.js 20 deprecation warning from GitHub Actions.