### PR TITLE
Update telemetry wrapper to 0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "md5": "^2.2.1",
         "minimatch": "^3.1.5",
         "semver": "^7.6.3",
-        "vscode-extension-telemetry-wrapper": "^0.15.1",
+        "vscode-extension-telemetry-wrapper": "^0.15.2",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-tas-client": "^0.1.84",
@@ -263,6 +263,21 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
@@ -3719,11 +3734,12 @@
       "license": "MIT"
     },
     "node_modules/vscode-extension-telemetry-wrapper": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
-      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.2.tgz",
+      "integrity": "sha512-efKkHF8c4kTKyBhBH2k0bZU4drqIic2jBYw/j1ixKOEEsa/WIiuUsdrBPD5uaRIoZ/91GzNCLiiV4ckIrf581g==",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       }
     },
@@ -4259,6 +4275,17 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
@@ -6750,10 +6777,11 @@
       "dev": true
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
-      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.2.tgz",
+      "integrity": "sha512-efKkHF8c4kTKyBhBH2k0bZU4drqIic2jBYw/j1ixKOEEsa/WIiuUsdrBPD5uaRIoZ/91GzNCLiiV4ckIrf581g==",
       "requires": {
+        "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "md5": "^2.2.1",
         "minimatch": "^3.1.5",
         "semver": "^7.6.3",
-        "vscode-extension-telemetry-wrapper": "^0.14.0",
+        "vscode-extension-telemetry-wrapper": "^0.15.1",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-tas-client": "^0.1.84",
@@ -228,118 +228,111 @@
       }
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.0.tgz",
-      "integrity": "sha512-0aP0ko4j0E2HfMNG1TdctGxcX74c4nQMMMV2JyaBYRRlbg1qYSVCUTZO4Ap6Qf65cBjJUCoIzgDMXNSquANwDA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.4.1.tgz",
+      "integrity": "sha512-utqwacfUkiGJROn4WC7aNdRBsRxwhNWXuqaJM2B0N0WHmv1+IhSuI7RQ3FHwxRP1dxZi/xn9aELMZ7HMStsW1w==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.0",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.0.tgz",
-      "integrity": "sha512-a1AflEuB313mfRiNNqkoVYDi4zxnG57zR8KotudtVoov6hiByBIS0KSuf3oE5/woDHWi9ZJjiCDvFwNqNH0YYw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.4.1.tgz",
+      "integrity": "sha512-CkFEhDY7X8E2JLr6HsEvRiC0DaLOCsA7vlbq/9DJP65gAumgw2NnFNIAOg6Je5Geq1LDu76/nb2hP34p8eGggw==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "4.3.0",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.0.tgz",
-      "integrity": "sha512-xlxcfwgFgvHoY/STVgtRoUSvAKOMNbe4CIBeY8zTHsjE9x3/kY9R9kpRkTBectuD7xVm1/FmzrzqaxcJO7R/sw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "3.3.0",
-        "@microsoft/applicationinsights-core-js": "3.3.0",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.0.tgz",
-      "integrity": "sha512-5t6WtL9wCQUA06sioaTenz5qWgrCk7QRm99pDuP+vyjcAiT6//f+Qn1K9KXtEX5WfEMHx3vBIDGLl6ppnF1YAQ==",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.0",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.0.tgz",
-      "integrity": "sha512-so0fFTqgZMjClH+MsiRYGspo5fpgwHEUYNMjyzpf9rjrY7FaUH8kkWzrQ3V0Cs4axZwf+WuIndtDOAws7aBmGQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-shims": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
       "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.0.tgz",
-      "integrity": "sha512-8+QcrgensCK44XuHMkW+zQXYchM6/f5gg0go/REVj5DpbE03L3jXNajSlBIALH8MzhGgcyPDlGmIt2OYztUMNQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.1.tgz",
+      "integrity": "sha512-V/hSlauFp1thJa57+TMv5mAYinJAQUi4zOmDmpahnDgs8g1zrQ0D8QYDmu0Zfi+9GhoD80B4yJez2+ydJPJz2w==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "3.3.0",
-        "@microsoft/applicationinsights-common": "3.3.0",
-        "@microsoft/applicationinsights-core-js": "3.3.0",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/dynamicproto-js": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
       "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+      "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.2.tgz",
-      "integrity": "sha512-Zf2vUNjCw2vJsiVKhWXA9hCNHsn59AOSGa5jGP4tWrp/vTH9XrI4eG/65khuoAgrS83migj0Xv5/j6fUAz69Zw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
+      "license": "MIT",
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.3.tgz",
-      "integrity": "sha512-oipW+tyKN68bREjoESYAzOZiatM+1LF+ez1TX3BaeinhCkI18xsLgmpH9tvwHaVgKf1Tsth25sdbXVtYmgRYvQ=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -718,13 +711,14 @@
       "dev": true
     },
     "node_modules/@vscode/extension-telemetry": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.6.tgz",
-      "integrity": "sha512-qWK2GNw+b69QRYpjuNM9g3JKToMICoNIdc0rQMtvb4gIG9vKKCZCVCz+ZOx6XM/YlfWAyuPiyxcjIY0xyF+Djg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.5.1.tgz",
+      "integrity": "sha512-rnRRQIRCwRdbcQ0QV5ajKJRz8noEIoQA2hX9VjAlVAVB85+ClbaPNhljobFXgW31ue69FRO6KPE4XJ/lLgKt/Q==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^4.1.2",
-        "@microsoft/1ds-post-js": "^4.1.2",
-        "@microsoft/applicationinsights-web-basic": "^3.1.2"
+        "@microsoft/1ds-core-js": "^4.3.10",
+        "@microsoft/1ds-post-js": "^4.3.10",
+        "@microsoft/applicationinsights-web-basic": "^3.3.10"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -3717,14 +3711,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -3733,12 +3719,12 @@
       "license": "MIT"
     },
     "node_modules/vscode-extension-telemetry-wrapper": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.14.0.tgz",
-      "integrity": "sha512-EYr1hqiYVSGfupchDN405zSwuvA8V3tJ62KcLIRDr/4ongOc2AvSZ0BlRq8a0w950tadsMlXTKEheB97fZBttg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
+      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vscode/extension-telemetry": "^0.9.6",
-        "uuid": "^8.3.2"
+        "@vscode/extension-telemetry": "^1.2.0"
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -4241,62 +4227,50 @@
       }
     },
     "@microsoft/1ds-core-js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.0.tgz",
-      "integrity": "sha512-0aP0ko4j0E2HfMNG1TdctGxcX74c4nQMMMV2JyaBYRRlbg1qYSVCUTZO4Ap6Qf65cBjJUCoIzgDMXNSquANwDA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.4.1.tgz",
+      "integrity": "sha512-utqwacfUkiGJROn4WC7aNdRBsRxwhNWXuqaJM2B0N0WHmv1+IhSuI7RQ3FHwxRP1dxZi/xn9aELMZ7HMStsW1w==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "3.3.0",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/1ds-post-js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.0.tgz",
-      "integrity": "sha512-a1AflEuB313mfRiNNqkoVYDi4zxnG57zR8KotudtVoov6hiByBIS0KSuf3oE5/woDHWi9ZJjiCDvFwNqNH0YYw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.4.1.tgz",
+      "integrity": "sha512-CkFEhDY7X8E2JLr6HsEvRiC0DaLOCsA7vlbq/9DJP65gAumgw2NnFNIAOg6Je5Geq1LDu76/nb2hP34p8eGggw==",
       "requires": {
-        "@microsoft/1ds-core-js": "4.3.0",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/applicationinsights-channel-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.0.tgz",
-      "integrity": "sha512-xlxcfwgFgvHoY/STVgtRoUSvAKOMNbe4CIBeY8zTHsjE9x3/kY9R9kpRkTBectuD7xVm1/FmzrzqaxcJO7R/sw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
       "requires": {
-        "@microsoft/applicationinsights-common": "3.3.0",
-        "@microsoft/applicationinsights-core-js": "3.3.0",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
-      }
-    },
-    "@microsoft/applicationinsights-common": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.0.tgz",
-      "integrity": "sha512-5t6WtL9wCQUA06sioaTenz5qWgrCk7QRm99pDuP+vyjcAiT6//f+Qn1K9KXtEX5WfEMHx3vBIDGLl6ppnF1YAQ==",
-      "requires": {
-        "@microsoft/applicationinsights-core-js": "3.3.0",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.0.tgz",
-      "integrity": "sha512-so0fFTqgZMjClH+MsiRYGspo5fpgwHEUYNMjyzpf9rjrY7FaUH8kkWzrQ3V0Cs4axZwf+WuIndtDOAws7aBmGQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
       "requires": {
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/applicationinsights-shims": {
@@ -4308,17 +4282,16 @@
       }
     },
     "@microsoft/applicationinsights-web-basic": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.0.tgz",
-      "integrity": "sha512-8+QcrgensCK44XuHMkW+zQXYchM6/f5gg0go/REVj5DpbE03L3jXNajSlBIALH8MzhGgcyPDlGmIt2OYztUMNQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.1.tgz",
+      "integrity": "sha512-V/hSlauFp1thJa57+TMv5mAYinJAQUi4zOmDmpahnDgs8g1zrQ0D8QYDmu0Zfi+9GhoD80B4yJez2+ydJPJz2w==",
       "requires": {
-        "@microsoft/applicationinsights-channel-js": "3.3.0",
-        "@microsoft/applicationinsights-common": "3.3.0",
-        "@microsoft/applicationinsights-core-js": "3.3.0",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/dynamicproto-js": {
@@ -4330,17 +4303,17 @@
       }
     },
     "@nevware21/ts-async": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.2.tgz",
-      "integrity": "sha512-Zf2vUNjCw2vJsiVKhWXA9hCNHsn59AOSGa5jGP4tWrp/vTH9XrI4eG/65khuoAgrS83migj0Xv5/j6fUAz69Zw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
       "requires": {
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "@nevware21/ts-utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.3.tgz",
-      "integrity": "sha512-oipW+tyKN68bREjoESYAzOZiatM+1LF+ez1TX3BaeinhCkI18xsLgmpH9tvwHaVgKf1Tsth25sdbXVtYmgRYvQ=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4615,13 +4588,13 @@
       "dev": true
     },
     "@vscode/extension-telemetry": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.6.tgz",
-      "integrity": "sha512-qWK2GNw+b69QRYpjuNM9g3JKToMICoNIdc0rQMtvb4gIG9vKKCZCVCz+ZOx6XM/YlfWAyuPiyxcjIY0xyF+Djg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.5.1.tgz",
+      "integrity": "sha512-rnRRQIRCwRdbcQ0QV5ajKJRz8noEIoQA2hX9VjAlVAVB85+ClbaPNhljobFXgW31ue69FRO6KPE4XJ/lLgKt/Q==",
       "requires": {
-        "@microsoft/1ds-core-js": "^4.1.2",
-        "@microsoft/1ds-post-js": "^4.1.2",
-        "@microsoft/applicationinsights-web-basic": "^3.1.2"
+        "@microsoft/1ds-core-js": "^4.3.10",
+        "@microsoft/1ds-post-js": "^4.3.10",
+        "@microsoft/applicationinsights-web-basic": "^3.3.10"
       }
     },
     "@webassemblyjs/ast": {
@@ -6770,11 +6743,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6782,12 +6750,11 @@
       "dev": true
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.14.0.tgz",
-      "integrity": "sha512-EYr1hqiYVSGfupchDN405zSwuvA8V3tJ62KcLIRDr/4ongOc2AvSZ0BlRq8a0w950tadsMlXTKEheB97fZBttg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
+      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
       "requires": {
-        "@vscode/extension-telemetry": "^0.9.6",
-        "uuid": "^8.3.2"
+        "@vscode/extension-telemetry": "^1.2.0"
       }
     },
     "vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -866,7 +866,7 @@
     "md5": "^2.2.1",
     "minimatch": "^3.1.5",
     "semver": "^7.6.3",
-    "vscode-extension-telemetry-wrapper": "^0.15.1",
+    "vscode-extension-telemetry-wrapper": "^0.15.2",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-tas-client": "^0.1.84",

--- a/package.json
+++ b/package.json
@@ -866,7 +866,7 @@
     "md5": "^2.2.1",
     "minimatch": "^3.1.5",
     "semver": "^7.6.3",
-    "vscode-extension-telemetry-wrapper": "^0.14.0",
+    "vscode-extension-telemetry-wrapper": "^0.15.1",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-tas-client": "^0.1.84",


### PR DESCRIPTION
Update vscode-extension-telemetry-wrapper to 0.15.1.

This picks up the wrapper release that removes the vulnerable uuid dependency and uses Node's built-in crypto.randomUUID().