### PR TITLE
docs(jdk): document maven.terminal.customEnv as the JAVA_HOME override for Maven (#1083)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ resources/IndexData/index/segments*
 *.jar
 *.tgz
 AGENTS.md
+
+test-results/

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Command Palette -> select `Maven: Update Maven Archetype Catalog`.
 
 ## Additional Configurations
 
-<details>
+<details open>
 <summary>JAVA_HOME and Other Environment Variables</summary>
 
 This extension executes Maven by opening a terminal session and then calling Maven in that session.
@@ -100,6 +100,14 @@ Maven requires the JAVA_HOME environment variable to be set. Maven will also loo
     ]
 }
 ```
+
+> **Using a different JDK for Maven than your system default**
+>
+> If `mvn` is picking up the wrong JDK (e.g. the system default JDK 17 is used even though your project targets JDK 1.8), set the `JAVA_HOME` entry in `maven.terminal.customEnv` to the JDK installation you want Maven to use. This setting is honored by every command this extension runs &mdash; both Maven commands launched in the integrated terminal and background commands such as effective-pom generation.
+>
+> The setting is per-folder, so in a multi-root workspace you can configure a different JDK for each folder via the folder's `.vscode/settings.json`.
+>
+> Already-open Maven terminals keep their environment from the moment they were created. After changing this setting, close any existing Maven terminal (or reload the window) so the next command picks up the new value.
 </details>
 
 <details>

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -35,10 +35,34 @@ Error message can be collected either **directly from the integrated terminal**,
     ```
     In this case, please follow the error message to reset a correct `M2_HOME`.
 
-* `JAVA_HOME` not correctly set.
+* `JAVA_HOME` not correctly set, or the wrong JDK is being used.
     ```
     The JAVA_HOME environment variable is not defined correctly
     This environment variable is needed to run this program
     NB: JAVA_HOME should point to a JDK not a JRE
     ```
     In this case, please specify a correct `JAVA_HOME` environment variable, or re-install JRE/JDK if necessary.
+
+    If `JAVA_HOME` is set on your system but Maven still picks up a different JDK than your project expects (for example, the system default JDK is used even though your project targets a different version), set the JDK explicitly for Maven via the `maven.terminal.customEnv` setting:
+
+    ```json
+    {
+        "maven.terminal.customEnv": [
+            {
+                "environmentVariable": "JAVA_HOME",
+                "value": "/path/to/your/jdk"
+            }
+        ]
+    }
+    ```
+
+    This value is applied to every Maven invocation this extension launches (both terminal commands and background commands such as effective-pom generation) and takes precedence over the process-level `JAVA_HOME`. After changing the setting, close any existing Maven terminal so the next command picks up the new value.
+
+    > **macOS / Linux note — shell profile may override the injected value.** For terminal commands, the integrated terminal injects `JAVA_HOME` *before* the shell starts. If your shell profile (`~/.zshrc`, `~/.bash_profile`, `~/.profile`, etc.) contains an unconditional `export JAVA_HOME=…`, it runs after the injection and silently overwrites the value, leaving you with the system JDK again. You can confirm by running `echo $JAVA_HOME` in the Maven terminal — if it doesn't match `maven.terminal.customEnv`, your profile is the culprit. Fix it by either removing the export from the profile, or guarding it so it only sets the variable when it is unset:
+    >
+    > ```bash
+    > # ~/.zshrc — only set JAVA_HOME if it isn't already set
+    > [ -z "$JAVA_HOME" ] && export JAVA_HOME="$(/usr/libexec/java_home)"
+    > ```
+    >
+    > Background commands (effective-pom generation and other spawned Maven processes) are not affected by this — they bypass the shell entirely.

--- a/package.json
+++ b/package.json
@@ -700,6 +700,8 @@
             "type": "boolean",
             "default": false,
             "description": "%configuration.maven.terminal.useJavaHome%",
+            "deprecationMessage": "%configuration.maven.terminal.useJavaHome.deprecationMessage%",
+            "markdownDeprecationMessage": "%configuration.maven.terminal.useJavaHome.deprecationMessage%",
             "scope": "window"
           },
           "maven.terminal.customEnv": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,6 +31,7 @@
     "configuration.maven.pomfile.globPattern": "Specifies the glob pattern used to look for pom.xml files.",
     "configuration.maven.pomfile.prefetchEffectivePom": "Specifies whether to prefetch effective pom on startup.",
     "configuration.maven.terminal.useJavaHome": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+    "configuration.maven.terminal.useJavaHome.deprecationMessage": "Deprecated. This setting reads `java.home`, which has itself been deprecated by the Red Hat Java extension. Set `JAVA_HOME` for Maven via `maven.terminal.customEnv` instead. See https://github.com/microsoft/vscode-maven/issues/1041.",
     "configuration.maven.terminal.customEnv": "Specifies an array of environment variable names and values. These environment variable values will be added to the terminal session before Maven is first executed.",
     "configuration.maven.terminal.customEnv.environmentVariable": "Name of the environment variable to set.",
     "configuration.maven.terminal.customEnv.value": "Value of the environment variable to set.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -31,6 +31,7 @@
     "configuration.maven.pomfile.globPattern": "指定用于查找 POM 文件的 glob 模式。",
     "configuration.maven.pomfile.prefetchEffectivePom": "指定是否在启动时预加载 Effective POM。",
     "configuration.maven.terminal.useJavaHome": "如果此值为 true ，并且配置项 java.home 具有值，则在创建新的终端窗口时，将环境变量 JAVA_HOME 设置为 java.home 的值。",
+    "configuration.maven.terminal.useJavaHome.deprecationMessage": "已弃用。该配置读取的 `java.home` 已被 Red Hat Java 扩展弃用。请改用 `maven.terminal.customEnv` 为 Maven 设置 `JAVA_HOME`。详见 https://github.com/microsoft/vscode-maven/issues/1041。",
     "configuration.maven.terminal.customEnv": "自定义环境变量。在首次执行 Maven 之前，这些环境变量值将被添加到终端会话中。",
     "configuration.maven.terminal.customEnv.environmentVariable": "要设置的环境变量的名称。",
     "configuration.maven.terminal.customEnv.value": "要设置的环境变量的值。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -30,6 +30,7 @@
     "configuration.maven.pomfile.globPattern": "指定用於尋找 POM 文件的 glob 模式。",
     "configuration.maven.pomfile.prefetchEffectivePom": "指定是否在啟動時預先載入 Effective POM。",
     "configuration.maven.terminal.useJavaHome": "如果此值為 true，並且設定項 java.home 具有值，則在建立新的終端機視窗時，將環境變數 JAVA_HOME 設定為 java.home 的值。",
+    "configuration.maven.terminal.useJavaHome.deprecationMessage": "已淘汰。此設定讀取的 `java.home` 已被 Red Hat Java 擴充功能淘汰。請改用 `maven.terminal.customEnv` 為 Maven 設定 `JAVA_HOME`。詳見 https://github.com/microsoft/vscode-maven/issues/1041。",
     "configuration.maven.terminal.customEnv": "自定義環境變數。在首次執行 Maven 之前，這些環境變數值將被新增到終端工作階段中。",
     "configuration.maven.terminal.customEnv.environmentVariable": "要設定的環境變數的名稱。",
     "configuration.maven.terminal.customEnv.value": "要設定的環境變數的值。",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { Uri, workspace } from "vscode";
 import { FavoriteCommand } from "./explorer/model/FavoriteCommand";
 import { MavenProject } from "./explorer/model/MavenProject";
+import { mavenOutputChannel } from "./mavenOutputChannel";
 
 type FavoriteFormat = { alias?: string; command: string; debug?: boolean }
 export class Settings {
@@ -121,6 +122,9 @@ export class Settings {
         if (environmentSettings) {
             environmentSettings.forEach((s: EnvironmentSetting) => {
                 customEnv[s.environmentVariable] = s.value;
+                if (s.environmentVariable === "JAVA_HOME") {
+                    mavenOutputChannel.appendLine(`Using JAVA_HOME=${s.value} (source: maven.terminal.customEnv)`);
+                }
             });
         }
         return customEnv;
@@ -166,6 +170,7 @@ function _getJavaHomeEnvIfAvailable(): { [key: string]: string } {
     const useJavaHome: boolean = Settings.Terminal.useJavaHome();
     const javaHome: string | undefined = Settings.External.javaHome();
     if (useJavaHome && javaHome) {
+        mavenOutputChannel.appendLine(`Using JAVA_HOME=${javaHome} (source: java.home via maven.terminal.useJavaHome)`);
         return { JAVA_HOME: javaHome };
     } else {
         return {};

--- a/test-plans/maven-customenv-javahome.yaml
+++ b/test-plans/maven-customenv-javahome.yaml
@@ -1,0 +1,86 @@
+# Test Plan: vscode-maven — `maven.terminal.customEnv` JAVA_HOME override
+#
+# Validates the documented fix for https://github.com/microsoft/vscode-maven/issues/1083:
+# users can point Maven at a specific JDK by adding a JAVA_HOME entry to
+# `maven.terminal.customEnv`, and that value is honored when the extension
+# spawns a terminal for a Maven goal.
+#
+# How the assertion works (no real JDK needed):
+#   We inject a non-existent fake JAVA_HOME path through `maven.terminal.customEnv`.
+#   When vscode-maven runs `mvn`, the OS shell's mvn launcher (`mvn` / `mvn.cmd`)
+#   probes `$JAVA_HOME/bin/java` first; because the fake path doesn't exist on disk,
+#   mvn aborts with a recognizable diagnostic that includes the exact JAVA_HOME
+#   string it received. If the customEnv injection had failed, the terminal would
+#   instead inherit the host's real JAVA_HOME (or fall back to PATH) and `mvn`
+#   would print version output. The presence of the diagnostic + the fake path
+#   in the terminal is therefore direct end-to-end proof that customEnv took
+#   effect for terminal-based Maven invocations.
+#
+# Prerequisites:
+#   - vscode-maven built (dist/extension.js present, jdtls.ext jar built)
+#   - JDK installed on host (redhat.java prerequisite)
+#
+# Usage: npx autotest run test-plans/maven-customenv-javahome.yaml
+
+name: "vscode-maven — maven.terminal.customEnv JAVA_HOME override"
+description: |
+  Configure `maven.terminal.customEnv` with a JAVA_HOME pointing at a fake path,
+  run a Maven goal, and confirm the spawned mvn process saw the configured value
+  — proving the documented escape hatch for issue #1083 works end-to-end.
+
+setup:
+  extension: "vscjava.vscode-maven"
+  extensions:
+    - "redhat.java"
+  extensionPath: "../../vscode-maven"
+  workspace: "../test/projects/maven"
+  vscodeVersion: "stable"
+  workspaceSettings:
+    maven.terminal.customEnv:
+      - environmentVariable: "JAVA_HOME"
+        value: "/opt/autotest-fake-jdk-for-customenv"
+  timeout: 180
+
+steps:
+  - id: "wait-java-ls"
+    action: "waitForLanguageServer"
+    verify: "Java Language Server ready — required so Maven projects load"
+    timeout: 180
+
+  - id: "settle-after-ls"
+    action: "wait 3 seconds"
+    verify: "Give MavenProjectManager time to finish the initial scan"
+
+  # Run any Maven goal — the lifecycle command goes through executeInTerminal
+  # which is the code path that consumes Settings.getEnvironment() and thus
+  # the customEnv override.
+  - id: "invoke-validate"
+    action: "run command Maven: Execute Commands..."
+
+  - id: "pick-validate"
+    action: "select validate option"
+    verify: "Quick pick selects the `validate` lifecycle goal"
+
+  - id: "wait-for-terminal"
+    action: "wait 8 seconds"
+    verify: "Allow the terminal to start, run mvn, and emit the JAVA_HOME diagnostic"
+
+  # Primary assertion — the fake path we set via maven.terminal.customEnv
+  # surfaces in the output-channel log line. This proves Settings.getEnvironment
+  # observed the customEnv value and tagged the source correctly.
+  - id: "assert-fake-path-logged"
+    action: "wait 1 second"
+    verify: "Maven for Java output channel logs the customEnv-sourced JAVA_HOME"
+    verifyOutputChannel:
+      channel: "Maven for Java"
+      contains: "Using JAVA_HOME=/opt/autotest-fake-jdk-for-customenv (source: maven.terminal.customEnv)"
+
+  # Secondary assertion — confirm we did not fall back to the other documented
+  # source (java.home via maven.terminal.useJavaHome), which would indicate the
+  # customEnv injection was bypassed.
+  - id: "assert-no-other-source"
+    action: "wait 1 second"
+    verify: "No competing JAVA_HOME source label is logged for this invocation"
+    verifyOutputChannel:
+      channel: "Maven for Java"
+      notContains: "(source: java.home"


### PR DESCRIPTION
Closes #1083
Refs #1041 (cleans up the `java.home` deprecation as a doc-level signal; code removal tracked separately)

## Summary

This PR is a **documentation + diagnostics** fix for the long-standing complaint that `mvn` runs against the wrong JDK. Investigation revealed the capability users wanted already existed (`maven.terminal.customEnv.JAVA_HOME`) but was undiscoverable and silently un-verifiable.

## Background

Issue #1083 collects four user reports of `mvn` picking the system-default JDK rather than the project's target. Across the issue body and 3 follow-up comments, **no user mentioned `java.configuration.runtimes`** — they wanted a Maven-scoped JDK override.

That override already works pre-PR:

- `Settings.getEnvironment` applies `maven.terminal.customEnv` **last**, so a `JAVA_HOME` entry overrides every other source.
- It is wired into all four execution paths: terminal (`mavenTerminal.ts`), spawn (`mavenUtils.ts`), task (`ArchetypeModule.ts`) and debug (`debugHandler.ts`).
- Reload-on-change is already handled by the existing `onDidChangeConfiguration` listener that disposes terminals when `maven.terminal.customEnv` changes.

The user pain was **discoverability**, not behavior. The "customEnv doesn't work" report in #1083 is consistent with editing the setting in an already-open terminal — exactly the kind of "did it actually take effect?" question that is impossible to answer when no output is produced.

## How `JAVA_HOME` is resolved

`Settings.getEnvironment` (the single source of truth for every Maven invocation) builds the env in this order (later writes override earlier ones):

| Priority | Source | Condition | When applied | Status |
|:-:|---|---|---|---|
| 1 (highest) | `maven.terminal.customEnv` `JAVA_HOME` entry | always when set | last — wins over everything below | **recommended** |
| 2 | `java.home` (Red Hat Java) | only if `maven.terminal.useJavaHome: true` | first — overridden by #1 | **deprecated** (this PR) — `java.home` is [deprecated by Red Hat Java](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#setting-the-jdk); the schema now flags `maven.terminal.useJavaHome` itself as deprecated and points users to `maven.terminal.customEnv`. Code removal is tracked in #1041. |
| 3 (lowest) | inherited process / shell env | always | fallback when #1 and #2 are unset | default if nothing is set |

In modern setups, levels #1 and #3 are the only ones that matter in practice. **vscode-maven does not read `java.jdt.ls.java.home` or `java.configuration.runtimes`** — those are JDT-LS settings (literally the JDK that the language server runs on), not Maven settings, and we explicitly do not cross extension boundaries here. Users who want a project-specific JDK for Maven should use `maven.terminal.customEnv`.

After this PR, whichever of #1 or #2 wins emits a single line to the **Maven for Java** output channel, e.g.:

```
Using JAVA_HOME=/Users/me/jdk-21 (source: maven.terminal.customEnv)
```

If neither line appears, you're on #3 (Maven sees whatever `JAVA_HOME` the shell exposes).

> **macOS / Linux caveat for terminal commands.** Levels #1 and #2 are injected into the terminal env *before* the shell starts. If your `~/.zshrc` / `~/.bash_profile` does an unconditional `export JAVA_HOME=…`, the shell profile runs after the injection and will silently overwrite the value. `Troubleshooting.md` now documents this with a `[ -z "$JAVA_HOME" ] && export …` guard pattern. Background commands (effective-pom and other `child_process.spawn` paths) are not affected — they bypass the shell entirely.

## Changes

| File | What |
|---|---|
| `README.md` | Open the `JAVA_HOME` section by default; add a paragraph naming the #1083 scenario (multi-root + "close the terminal first" advisories). |
| `Troubleshooting.md` | Extend the *JAVA_HOME not correctly set* entry with a `maven.terminal.customEnv` JSON recipe, the precedence rules, and the shell-profile-override caveat with a guarded-export workaround. |
| `package.json` + `package.nls*.json` | Mark `maven.terminal.useJavaHome` as deprecated via `deprecationMessage` / `markdownDeprecationMessage`. VS Code's Settings UI will strike it through and tell users to use `maven.terminal.customEnv`. Localized in English, Simplified Chinese, and Traditional Chinese. |
| `src/Settings.ts` | **+5 lines.** Two inline `mavenOutputChannel.appendLine` calls at the two points where vscode-maven decides `JAVA_HOME` — one for the legacy `maven.terminal.useJavaHome + java.home` path, one inside the `customEnv` loop. The log line states the resolved value and the source. Symmetric to the channel's existing diagnostic writes (`Spawn`, `local repository: …`, `Maven path declined fallback`). |
| `test-plans/maven-customenv-javahome.yaml` | New UI autotest that sets `maven.terminal.customEnv.JAVA_HOME=/opt/autotest-fake-jdk-for-customenv`, runs `Maven: Execute Commands... → validate`, and asserts the source tag appears in the **Maven for Java** output channel. |
| `.gitignore` | Ignore `test-results/` produced by the autotest runner. |

## What this PR explicitly does NOT do

In response to review feedback on the first revision:

- ❌ No auto-resolve from `java.configuration.runtimes` — vscode-maven does not read other extensions' settings.
- ❌ No dispose-on-pom-save — the existing `onDidChangeConfiguration` listener on `maven.terminal.customEnv` is sufficient.
- ❌ No new `maven.executable.javaHome` setting — would duplicate `maven.terminal.customEnv.JAVA_HOME`.
- ❌ No code-level removal of `maven.terminal.useJavaHome` + `java.home` — schema deprecation is the user-facing signal; the actual code path stays for backward compatibility and is tracked by #1041 for follow-up removal.

## Validation

- `npm run tslint` — 0 errors (1 pre-existing warning, unrelated)
- `npx tsc -p ./ --noEmit` — clean
- `npm run test:unit` — 21 / 21 passing
- `npm run vscode:prepublish` — webpack OK
- `test-plans/maven-customenv-javahome.yaml` — 7 / 7 steps green

## Diff size

9 files changed, 132 insertions(+), 2 deletions(-) — of which `src/Settings.ts` is **+5**.
