### PR TITLE
cleanup: remove deprecated maven.terminal.useJavaHome (#1041)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,26 +113,7 @@ Maven requires the JAVA_HOME environment variable to be set. Maven will also loo
 <details>
 <summary>Special Handling for JAVA_HOME</summary>
 
-If you have Red Hat's Java Language Support extension installed, then you can specify JAVA_HOME in settings for that extension:
-
-```json
-{
-    "java.home": "C:\\Program Files\\Java\\jdk-9.0.4"      // Red Hat Java Language Support Setting
-}
-```
-
-This extension (Maven for Java) can reuse that setting if you desire:
-
-```json
-{
-    "maven.terminal.useJavaHome": true      // Use the Red Hat Java Language Support Setting for JAVA_HOME
-}
-```
-
-With this support, you can specify JAVA_HOME in one place and you do not need to use the `maven.terminal.customEnv` setting unless
-you have other environment variables to set.
-
-If you have JAVA_HOME configured through the `maven.terminal.customEnv` setting, and also specify to reuse the Red Hat setting, then the value from `maven.terminal.customEnv` will take precedence.
+To run Maven with a specific JDK, set `JAVA_HOME` via `maven.terminal.customEnv` (see the section above). This value is applied to both terminal commands and background commands launched by this extension.
 
 </details>
 
@@ -200,7 +181,6 @@ Now right-click on an project item, and then click `Favorite ...`. The option `f
 | `maven.pomfile.autoUpdateEffectivePOM` | Specifies whether to update effective-pom automatically whenever changes detected. | `false` |
 | `maven.pomfile.globPattern` | Specifies the glob pattern used to look for pom.xml files. | `**/pom.xml` |
 | `maven.pomfile.prefetchEffectivePom` | Specifies whether to prefetch effective pom on startup. | `false` |
-| `maven.terminal.useJavaHome` | If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created. | `false` |
 | `maven.terminal.customEnv` | Specifies an array of environment variable names and values. These environment variable values will be added before Maven is executed. <br /> `environmentVariable`: Name of the environment variable to set. <br /> `value`: Value of the environment variable to set. | `[]` |
 | `maven.terminal.favorites` | Specify pre-defined favorite commands to execute. <br /> `alias`: A short name for the command. <br /> `command`: Content of the favorite command. | `[]` |
 | `maven.view` | Specifies the way of viewing Maven projects. Possible values: `flat`, `hierarchical`. | `flat` |

--- a/package.json
+++ b/package.json
@@ -696,14 +696,6 @@
             "description": "%configuration.maven.executable.options%",
             "scope": "machine-overridable"
           },
-          "maven.terminal.useJavaHome": {
-            "type": "boolean",
-            "default": false,
-            "description": "%configuration.maven.terminal.useJavaHome%",
-            "deprecationMessage": "%configuration.maven.terminal.useJavaHome.deprecationMessage%",
-            "markdownDeprecationMessage": "%configuration.maven.terminal.useJavaHome.deprecationMessage%",
-            "scope": "window"
-          },
           "maven.terminal.customEnv": {
             "type": "array",
             "items": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -30,8 +30,6 @@
     "configuration.maven.pomfile.autoUpdateEffectivePOM": "Specifies whether to update effective-pom automatically whenever changes detected.",
     "configuration.maven.pomfile.globPattern": "Specifies the glob pattern used to look for pom.xml files.",
     "configuration.maven.pomfile.prefetchEffectivePom": "Specifies whether to prefetch effective pom on startup.",
-    "configuration.maven.terminal.useJavaHome": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
-    "configuration.maven.terminal.useJavaHome.deprecationMessage": "Deprecated. This setting reads `java.home`, which has itself been deprecated by the Red Hat Java extension. Set `JAVA_HOME` for Maven via `maven.terminal.customEnv` instead. See https://github.com/microsoft/vscode-maven/issues/1041.",
     "configuration.maven.terminal.customEnv": "Specifies an array of environment variable names and values. These environment variable values will be added to the terminal session before Maven is first executed.",
     "configuration.maven.terminal.customEnv.environmentVariable": "Name of the environment variable to set.",
     "configuration.maven.terminal.customEnv.value": "Value of the environment variable to set.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -30,8 +30,6 @@
     "configuration.maven.pomfile.autoUpdateEffectivePOM": "指定是否自动更新 Effective POM。",
     "configuration.maven.pomfile.globPattern": "指定用于查找 POM 文件的 glob 模式。",
     "configuration.maven.pomfile.prefetchEffectivePom": "指定是否在启动时预加载 Effective POM。",
-    "configuration.maven.terminal.useJavaHome": "如果此值为 true ，并且配置项 java.home 具有值，则在创建新的终端窗口时，将环境变量 JAVA_HOME 设置为 java.home 的值。",
-    "configuration.maven.terminal.useJavaHome.deprecationMessage": "已弃用。该配置读取的 `java.home` 已被 Red Hat Java 扩展弃用。请改用 `maven.terminal.customEnv` 为 Maven 设置 `JAVA_HOME`。详见 https://github.com/microsoft/vscode-maven/issues/1041。",
     "configuration.maven.terminal.customEnv": "自定义环境变量。在首次执行 Maven 之前，这些环境变量值将被添加到终端会话中。",
     "configuration.maven.terminal.customEnv.environmentVariable": "要设置的环境变量的名称。",
     "configuration.maven.terminal.customEnv.value": "要设置的环境变量的值。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -29,8 +29,6 @@
     "configuration.maven.pomfile.autoUpdateEffectivePOM": "指定是否自動更新 Effective POM。",
     "configuration.maven.pomfile.globPattern": "指定用於尋找 POM 文件的 glob 模式。",
     "configuration.maven.pomfile.prefetchEffectivePom": "指定是否在啟動時預先載入 Effective POM。",
-    "configuration.maven.terminal.useJavaHome": "如果此值為 true，並且設定項 java.home 具有值，則在建立新的終端機視窗時，將環境變數 JAVA_HOME 設定為 java.home 的值。",
-    "configuration.maven.terminal.useJavaHome.deprecationMessage": "已淘汰。此設定讀取的 `java.home` 已被 Red Hat Java 擴充功能淘汰。請改用 `maven.terminal.customEnv` 為 Maven 設定 `JAVA_HOME`。詳見 https://github.com/microsoft/vscode-maven/issues/1041。",
     "configuration.maven.terminal.customEnv": "自定義環境變數。在首次執行 Maven 之前，這些環境變數值將被新增到終端工作階段中。",
     "configuration.maven.terminal.customEnv.environmentVariable": "要設定的環境變數的名稱。",
     "configuration.maven.terminal.customEnv.value": "要設定的環境變數的值。",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -52,20 +52,12 @@ export class Settings {
     }
 
     public static External = class {
-        public static javaHome(): string | undefined {
-            return workspace.getConfiguration("java").get<string>("home");
-        }
-
         public static defaultWindowsShell(): string | undefined {
             return workspace.getConfiguration("terminal").get<string>("integrated.shell.windows");
         }
     }
 
     public static Terminal = class {
-        public static useJavaHome(): boolean {
-            return !!_getMavenSection<boolean>("terminal.useJavaHome");
-        }
-
         public static customEnv(resourceOrFilepath?: Uri | string): {
             environmentVariable: string;
             value: string;
@@ -113,7 +105,7 @@ export class Settings {
     }
 
     public static getEnvironment(resourceOrFilepath?: Uri | string): { [key: string]: string } {
-        const customEnv: { [key: string]: string } = _getJavaHomeEnvIfAvailable();
+        const customEnv: { [key: string]: string } = {};
         type EnvironmentSetting = {
             environmentVariable: string;
             value: string;
@@ -162,17 +154,4 @@ function _getMavenSection<T>(section: string, resourceOrFilepath?: Uri | string)
         resource = resourceOrFilepath;
     }
     return workspace.getConfiguration("maven", resource).get<T>(section);
-}
-
-function _getJavaHomeEnvIfAvailable(): { [key: string]: string } {
-    // Look for the java.home setting from the redhat.java extension.  We can reuse it
-    // if it exists to avoid making the user configure it in two places.
-    const useJavaHome: boolean = Settings.Terminal.useJavaHome();
-    const javaHome: string | undefined = Settings.External.javaHome();
-    if (useJavaHome && javaHome) {
-        mavenOutputChannel.appendLine(`Using JAVA_HOME=${javaHome} (source: java.home via maven.terminal.useJavaHome)`);
-        return { JAVA_HOME: javaHome };
-    } else {
-        return {};
-    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,10 +214,7 @@ function registerPomFileWatcher(context: vscode.ExtensionContext): void {
 function registerConfigChangeListener(context: vscode.ExtensionContext): void {
     const configChangeListener: vscode.Disposable = vscode.workspace.onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
         // close all terminals with outdated JAVA related environment variables
-        if (e.affectsConfiguration("maven.terminal.useJavaHome")
-            || e.affectsConfiguration("maven.terminal.customEnv")
-            || e.affectsConfiguration("java.home") && Settings.Terminal.useJavaHome()
-        ) {
+        if (e.affectsConfiguration("maven.terminal.customEnv")) {
             mavenTerminal.dispose();
         }
         if (e.affectsConfiguration("maven.view")


### PR DESCRIPTION
Closes #1041
Follow-up to #1165 (which deprecated this setting at the schema level) and rebased on top of #1168 (test-plan stabilization + CI matrix refactor, now merged).

## Summary

Remove `maven.terminal.useJavaHome` and the related reading of the Red Hat Java extension's `java.home` setting. After #1165 marked the setting deprecated in `package.json` and pointed users to `maven.terminal.customEnv`, this PR completes the removal: schema entry, NLS strings, code path, and README references.

## Why now

- **Upstream is gone.** `java.home` has been deprecated by `redhat.java` for years.
- **The "obvious" replacement is wrong.** `java.jdt.ls.java.home` is the JDK that the JDT language server *runs on*, not the JDK the user''s project targets. With Red Hat planning to embed JRE 21 into JDT-LS, using it as the Maven JDK would actively mislead users. The discussion in #1041 (cypher256, apeteri, GreatGreenStar) reaches the same conclusion.
- **A correct replacement already exists and is documented.** `maven.terminal.customEnv` is Maven-scoped, applied to every execution path (terminal, spawn, task, debug), and respects workspace trust. README/Troubleshooting were updated in #1165.
- **Zero issue traction for the legacy path.** Across #1083 (4 reporters) and other recent issues, no user reports relying on `maven.terminal.useJavaHome`.

## Changes

| File | What |
|---|---|
| `src/Settings.ts` | Remove `Settings.External.javaHome()`, `Settings.Terminal.useJavaHome()`, and the `_getJavaHomeEnvIfAvailable()` helper. `getEnvironment` now starts from `{}` and is filled exclusively by `maven.terminal.customEnv`. The customEnv JAVA_HOME diagnostic log from #1165 is preserved. |
| `src/extension.ts` | Drop the `useJavaHome` / `java.home` branches from the JAVA-env config-change listener. The listener still disposes terminals on `maven.terminal.customEnv` changes. |
| `package.json` | Delete the `maven.terminal.useJavaHome` schema entry. |
| `package.nls.json`, `package.nls.zh-cn.json`, `package.nls.zh-tw.json` | Delete both NLS keys (description + deprecationMessage) for the removed setting. |
| `README.md` | Replace the "reuse `java.home`" example with a single sentence pointing to `maven.terminal.customEnv`; drop the corresponding row from the settings table. |

## Behavior

- Users who had `maven.terminal.useJavaHome: true` set will see VS Code mark the setting as "unknown configuration" (no error, no behavior change beyond losing the auto-injection). They get the deprecation pointer from #1165 already; this PR is the next major-version "actually delete it" step.
- Users on the recommended path (`maven.terminal.customEnv`): **no change at all**, since precedence and injection wiring are untouched.

## Validation

Local:
- `npx tsc -p ./ --noEmit` clean
- `npm run tslint` 0 errors (1 pre-existing warning, unrelated)
- `npm run test:unit` 21 / 21 passing
- `npm run vscode:prepublish` webpack OK

## Diff size

7 files changed, 3 insertions(+), 61 deletions(-).