### PR TITLE
fix(completion): timeout + CancellationToken for pom IntelliSense network calls (#1127)

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,6 +3,5 @@
   "spec": "test/unit/**/*.test.ts",
   "extension": ["ts"],
   "timeout": 15000,
-  "reporter": "spec",
-  "node-option": ["no-experimental-strip-types"]
+  "reporter": "spec"
 }

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,5 +3,6 @@
   "spec": "test/unit/**/*.test.ts",
   "extension": ["ts"],
   "timeout": 15000,
-  "reporter": "spec"
+  "reporter": "spec",
+  "node-option": ["no-experimental-strip-types"]
 }

--- a/package.json
+++ b/package.json
@@ -825,7 +825,7 @@
     "build-plugin": "node scripts/build-jdtls-ext.js",
     "compile": "tsc -p ./",
     "tslint": "eslint .",
-    "test:unit": "mocha",
+    "test:unit": "node scripts/run-unit-tests.js",
     "test:autotest": "node scripts/run-autotest-plans.js test-plans",
     "watch": "webpack --mode development --watch --progress",
     "webpack": "webpack --mode development",

--- a/scripts/run-unit-tests.js
+++ b/scripts/run-unit-tests.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Wrapper that invokes mocha for the unit-test suite.
+ *
+ * Why this exists:
+ *   Node 22.6+ ships `--experimental-strip-types` (on by default since 22.18).
+ *   When that flag is enabled, Mocha can load newly added `test/unit/*.test.ts`
+ *   files through Node's native ESM strip-types loader instead of the
+ *   `ts-node/register/transpile-only` CommonJS hook configured in
+ *   `.mocharc.json`. That breaks any test file that uses `require()`
+ *   (e.g. for `proxyquire`) with:
+ *     ReferenceError: require is not defined in ES module scope
+ *
+ *   The fix is to pass `--no-experimental-strip-types` to Node so that all
+ *   `.ts` test files load uniformly via ts-node. But that flag does not
+ *   exist on Node 20, where the project's CI still runs, so we cannot put
+ *   it directly in `.mocharc.json` — Node 20 would reject it as
+ *   `bad option`.
+ *
+ *   This wrapper detects the Node version at runtime and only forwards
+ *   the flag on Node 22.6+. Node 20 runs mocha exactly as before.
+ */
+
+"use strict";
+
+const { spawn } = require("child_process");
+
+const [major, minor] = process.versions.node.split(".").map(Number);
+const supportsStripTypesFlag = major > 22 || (major === 22 && minor >= 6);
+
+const nodeArgs = [];
+if (supportsStripTypesFlag) {
+    nodeArgs.push("--no-experimental-strip-types");
+}
+nodeArgs.push(require.resolve("mocha/bin/mocha.js"));
+nodeArgs.push(...process.argv.slice(2));
+
+const child = spawn(process.execPath, nodeArgs, { stdio: "inherit" });
+child.on("close", code => process.exit(code ?? 1));
+child.on("error", err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/completion/PomCompletionProvider.ts
+++ b/src/completion/PomCompletionProvider.ts
@@ -34,7 +34,10 @@ export class PomCompletionProvider implements vscode.CompletionItemProvider {
 
     }
 
-    async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem> | undefined> {
+    async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem> | undefined> {
+        if (token.isCancellationRequested) {
+            return undefined;
+        }
         const documentText: string = document.getText();
         const cursorOffset: number = document.offsetAt(position);
         const currentNode: Node | undefined = getCurrentNode(documentText, cursorOffset);
@@ -42,10 +45,17 @@ export class PomCompletionProvider implements vscode.CompletionItemProvider {
             return undefined;
         }
 
-        const ret = [];
-        for (const provider of this.providers) {
-            ret.push(...await provider.provide(document, position, currentNode));
+        const results = await Promise.all(
+            this.providers.map(provider =>
+                provider.provide(document, position, currentNode, token).catch(err => {
+                    console.error(err);
+                    return [] as vscode.CompletionItem[];
+                })
+            )
+        );
+        if (token.isCancellationRequested) {
+            return undefined;
         }
-        return ret;
+        return ([] as vscode.CompletionItem[]).concat(...results);
     }
 }

--- a/src/completion/providers/ArtifactProvider.ts
+++ b/src/completion/providers/ArtifactProvider.ts
@@ -22,7 +22,7 @@ export class ArtifactProvider implements IXmlCompletionProvider {
         this.localProvider = new FromLocal();
     }
 
-    async provide(document: vscode.TextDocument, position: vscode.Position, currentNode: Node): Promise<vscode.CompletionItem[]> {
+    async provide(document: vscode.TextDocument, position: vscode.Position, currentNode: Node, token?: vscode.CancellationToken): Promise<vscode.CompletionItem[]> {
         let tagNode: Element | undefined;
         if (isTag(currentNode)) {
             tagNode = currentNode;
@@ -48,9 +48,11 @@ export class ArtifactProvider implements IXmlCompletionProvider {
                 const groupIdHint: string = getTextFromNode(groupIdTextNode);
                 const artifactIdHint: string = getTextFromNode(artifactIdTextNode);
 
-                const centralItems: vscode.CompletionItem[] = await this.centralProvider.getGroupIdCandidates(groupIdHint, artifactIdHint);
-                const indexItems: vscode.CompletionItem[] = await this.indexProvider.getGroupIdCandidates(groupIdHint, artifactIdHint);
-                const localItems: vscode.CompletionItem[] = await this.localProvider.getGroupIdCandidates(groupIdHint);
+                const [centralItems, indexItems, localItems] = await settledAll([
+                    this.centralProvider.getGroupIdCandidates(groupIdHint, artifactIdHint, token),
+                    this.indexProvider.getGroupIdCandidates(groupIdHint, artifactIdHint),
+                    this.localProvider.getGroupIdCandidates(groupIdHint),
+                ]);
                 const mergedItems: vscode.CompletionItem[] = _.unionBy(centralItems, indexItems, localItems, (item) => item.insertText);
                 mergedItems.forEach(item => item.range = targetRange);
                 return mergedItems;
@@ -69,9 +71,11 @@ export class ArtifactProvider implements IXmlCompletionProvider {
                 const groupIdHint: string = getTextFromNode(groupIdTextNode);
                 const artifactIdHint: string = getTextFromNode(artifactIdTextNode);
 
-                const centralItems: vscode.CompletionItem[] = await this.centralProvider.getArtifactIdCandidates(groupIdHint, artifactIdHint);
-                const indexItems: vscode.CompletionItem[] = await this.indexProvider.getArtifactIdCandidates(groupIdHint, artifactIdHint);
-                const localItems: vscode.CompletionItem[] = await this.localProvider.getArtifactIdCandidates(groupIdHint);
+                const [centralItems, indexItems, localItems] = await settledAll([
+                    this.centralProvider.getArtifactIdCandidates(groupIdHint, artifactIdHint, token),
+                    this.indexProvider.getArtifactIdCandidates(groupIdHint, artifactIdHint),
+                    this.localProvider.getArtifactIdCandidates(groupIdHint),
+                ]);
                 let mergedItems: vscode.CompletionItem[] = [];
 
                 const ID_SEPARATOR = ":";
@@ -110,9 +114,11 @@ export class ArtifactProvider implements IXmlCompletionProvider {
                     return [];
                 }
 
-                const centralItems: vscode.CompletionItem[] = await this.centralProvider.getVersionCandidates(groupIdHint, artifactIdHint);
-                const indexItems: vscode.CompletionItem[] = await this.indexProvider.getVersionCandidates(groupIdHint, artifactIdHint);
-                const localItems: vscode.CompletionItem[] = await this.localProvider.getVersionCandidates(groupIdHint, artifactIdHint);
+                const [centralItems, indexItems, localItems] = await settledAll([
+                    this.centralProvider.getVersionCandidates(groupIdHint, artifactIdHint, undefined, token),
+                    this.indexProvider.getVersionCandidates(groupIdHint, artifactIdHint),
+                    this.localProvider.getVersionCandidates(groupIdHint, artifactIdHint),
+                ]);
                 const mergedItems: vscode.CompletionItem[] = _.unionBy(centralItems, indexItems, localItems, (item) => item.insertText);
                 mergedItems.forEach(item => item.range = targetRange);
                 return mergedItems;
@@ -120,6 +126,17 @@ export class ArtifactProvider implements IXmlCompletionProvider {
         }
         return [];
     }
+}
+
+async function settledAll(promises: Promise<vscode.CompletionItem[]>[]): Promise<vscode.CompletionItem[][]> {
+    const results = await Promise.allSettled(promises);
+    return results.map(r => {
+        if (r.status === "fulfilled") {
+            return r.value;
+        }
+        console.error(r.reason);
+        return [];
+    });
 }
 
 function getRange(node: Node | null, document: vscode.TextDocument, fallbackPosition?: vscode.Position) {

--- a/src/completion/providers/IXmlCompletionProvider.ts
+++ b/src/completion/providers/IXmlCompletionProvider.ts
@@ -5,5 +5,5 @@ import { Node } from "domhandler";
 import * as vscode from "vscode";
 
 export interface IXmlCompletionProvider {
-    provide(document: vscode.TextDocument, position: vscode.Position, currentNode: Node): Promise<vscode.CompletionItem[]>;
+    provide(document: vscode.TextDocument, position: vscode.Position, currentNode: Node, token?: vscode.CancellationToken): Promise<vscode.CompletionItem[]>;
 }

--- a/src/completion/providers/artifact/FromCentral.ts
+++ b/src/completion/providers/artifact/FromCentral.ts
@@ -8,9 +8,9 @@ import { IArtifactCompletionProvider } from "./IArtifactProvider";
 import { getSortText } from "../../utils";
 
 export class FromCentral implements IArtifactCompletionProvider {
-    public async getGroupIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {
+    public async getGroupIdCandidates(groupIdHint: string, artifactIdHint: string, token?: vscode.CancellationToken): Promise<vscode.CompletionItem[]> {
         const keywords: string[] = [...groupIdHint.split("."), ...artifactIdHint.split("-")];
-        const docs: IArtifactMetadata[] = await getArtifacts(keywords);
+        const docs: IArtifactMetadata[] = await getArtifacts(keywords, token);
         const groupIds: string[] = Array.from(new Set(docs.map(doc => doc.g)).values());
         const commandOnSelection: vscode.Command = {
             title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
@@ -25,9 +25,9 @@ export class FromCentral implements IArtifactCompletionProvider {
         });
     }
 
-    public async getArtifactIdCandidates(groupIdHint: string, artifactIdHint: string): Promise<vscode.CompletionItem[]> {
+    public async getArtifactIdCandidates(groupIdHint: string, artifactIdHint: string, token?: vscode.CancellationToken): Promise<vscode.CompletionItem[]> {
         const keywords: string[] = [...groupIdHint.split("."), ...artifactIdHint.split("-")];
-        const docs: IArtifactMetadata[] = await getArtifacts(keywords);
+        const docs: IArtifactMetadata[] = await getArtifacts(keywords, token);
         const commandOnSelection: vscode.Command = {
             title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
             arguments: [{ infoName: INFO_COMPLETION_ITEM_SELECTED, completeFor: "artifactId", source: "maven-central" }]
@@ -45,12 +45,12 @@ export class FromCentral implements IArtifactCompletionProvider {
         });
     }
 
-    public async getVersionCandidates(groupId: string, artifactId: string): Promise<vscode.CompletionItem[]> {
+    public async getVersionCandidates(groupId: string, artifactId: string, _versionHint?: string, token?: vscode.CancellationToken): Promise<vscode.CompletionItem[]> {
         if (!groupId && !artifactId) {
             return [];
         }
 
-        const docs: IVersionMetadata[] = await getVersions(groupId, artifactId);
+        const docs: IVersionMetadata[] = await getVersions(groupId, artifactId, token);
         const commandOnSelection: vscode.Command = {
             title: "selected", command: COMMAND_COMPLETION_ITEM_SELECTED,
             arguments: [{ infoName: INFO_COMPLETION_ITEM_SELECTED, completeFor: "version", source: "maven-central" }]

--- a/src/completion/providers/artifact/IArtifactProvider.ts
+++ b/src/completion/providers/artifact/IArtifactProvider.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { CompletionItem } from "vscode";
+import { CancellationToken, CompletionItem } from "vscode";
 
 export interface IArtifactCompletionProvider {
-    getGroupIdCandidates(groupIdHint?: string, artifactIdHint?: string): Promise<CompletionItem[]>;
-    getArtifactIdCandidates(groupIdHint?: string, artifactIdHint?: string): Promise<CompletionItem[]>;
-    getVersionCandidates(groupIdHint?: string, artifactIdHint?: string, versionHint?: string): Promise<CompletionItem[]>;
+    getGroupIdCandidates(groupIdHint?: string, artifactIdHint?: string, token?: CancellationToken): Promise<CompletionItem[]>;
+    getArtifactIdCandidates(groupIdHint?: string, artifactIdHint?: string, token?: CancellationToken): Promise<CompletionItem[]>;
+    getVersionCandidates(groupIdHint?: string, artifactIdHint?: string, versionHint?: string, token?: CancellationToken): Promise<CompletionItem[]>;
 }

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -6,10 +6,12 @@ import * as https from "https";
 import * as _ from "lodash";
 import * as path from "path";
 import * as url from "url";
+import * as vscode from "vscode";
 
 const URL_MAVEN_SEARCH_API = "https://search.maven.org/solrsearch/select";
 const URL_MAVEN_CENTRAL_REPO = "https://repo1.maven.org/maven2/";
 const MAVEN_METADATA_FILENAME = "maven-metadata.xml";
+const HTTPS_GET_TIMEOUT_MS = 10_000;
 
 export interface IArtifactMetadata {
     id: string;
@@ -28,7 +30,7 @@ export interface IVersionMetadata {
     timestamp: number;
 }
 
-export async function getArtifacts(keywords: string[]): Promise<IArtifactMetadata[]> {
+export async function getArtifacts(keywords: string[], token?: vscode.CancellationToken): Promise<IArtifactMetadata[]> {
     // Remove short keywords
     const validKeywords: string[] = keywords.filter(keyword => keyword.length >= 3);
     if (validKeywords.length === 0) {
@@ -40,8 +42,8 @@ export async function getArtifacts(keywords: string[]): Promise<IArtifactMetadat
         rows: 50,
         wt: "json"
     };
-    const raw: string = await httpsGet(`${URL_MAVEN_SEARCH_API}?${toQueryString(params)}`);
     try {
+        const raw: string = await httpsGet(`${URL_MAVEN_SEARCH_API}?${toQueryString(params)}`, token);
         return _.get(JSON.parse(raw), "response.docs", []);
     } catch (error) {
         console.error(error);
@@ -49,15 +51,15 @@ export async function getArtifacts(keywords: string[]): Promise<IArtifactMetadat
     }
 }
 
-export async function getVersions(gid: string, aid: string): Promise<IVersionMetadata[]> {
+export async function getVersions(gid: string, aid: string, token?: vscode.CancellationToken): Promise<IVersionMetadata[]> {
     const params = {
         q: `g:"${gid}" AND a:"${aid}"`,
         core: "gav",
         rows: 50,
         wt: "json"
     };
-    const raw: string = await httpsGet(`${URL_MAVEN_SEARCH_API}?${toQueryString(params)}`);
     try {
+        const raw: string = await httpsGet(`${URL_MAVEN_SEARCH_API}?${toQueryString(params)}`, token);
         return _.get(JSON.parse(raw), "response.docs", []);
     } catch (error) {
         console.error(error);
@@ -80,25 +82,56 @@ export async function getLatestVersion(gid: string, aid: string): Promise<string
     }
 }
 
-async function httpsGet(urlString: string): Promise<string> {
+async function httpsGet(urlString: string, token?: vscode.CancellationToken): Promise<string> {
     return new Promise<string>((resolve, reject) => {
+        if (token?.isCancellationRequested) {
+            reject(new Error("Cancelled"));
+            return;
+        }
+
         let result = "";
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const options: any = url.parse(urlString);
         options.headers = {
             'User-Agent': 'vscode-maven/0.1'
-        }
-        https.get(options, (res: http.IncomingMessage) => {
+        };
+        options.timeout = HTTPS_GET_TIMEOUT_MS;
+
+        let settled = false;
+        let cancelSub: vscode.Disposable | undefined;
+        const settle = (fn: () => void) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            cancelSub?.dispose();
+            fn();
+        };
+
+        const req = https.get(options, (res: http.IncomingMessage) => {
             res.on("data", chunk => {
                 result = result.concat(chunk.toString());
             });
             res.on("end", () => {
-                resolve(result);
+                settle(() => resolve(result));
             });
             res.on("error", err => {
-                reject(err);
+                settle(() => reject(err));
             });
         });
+
+        req.on("timeout", () => {
+            req.destroy(new Error(`HTTPS request to ${urlString} timed out after ${HTTPS_GET_TIMEOUT_MS}ms`));
+        });
+        req.on("error", err => {
+            settle(() => reject(err));
+        });
+
+        if (token) {
+            cancelSub = token.onCancellationRequested(() => {
+                req.destroy(new Error("Cancelled"));
+            });
+        }
     });
 }
 

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -13,6 +13,23 @@ const URL_MAVEN_CENTRAL_REPO = "https://repo1.maven.org/maven2/";
 const MAVEN_METADATA_FILENAME = "maven-metadata.xml";
 const HTTPS_GET_TIMEOUT_MS = 10_000;
 
+/**
+ * Error thrown when an httpsGet call is aborted because its CancellationToken
+ * was cancelled (e.g. the user kept typing, so VS Code superseded the previous
+ * completion request). Callers should swallow this silently — it is not a
+ * real failure.
+ */
+class CancellationError extends Error {
+    constructor() {
+        super("Cancelled");
+        this.name = "CancellationError";
+    }
+}
+
+function isCancellation(error: unknown): boolean {
+    return error instanceof CancellationError;
+}
+
 export interface IArtifactMetadata {
     id: string;
     g: string;
@@ -46,7 +63,9 @@ export async function getArtifacts(keywords: string[], token?: vscode.Cancellati
         const raw: string = await httpsGet(`${URL_MAVEN_SEARCH_API}?${toQueryString(params)}`, token);
         return _.get(JSON.parse(raw), "response.docs", []);
     } catch (error) {
-        console.error(error);
+        if (!isCancellation(error)) {
+            console.error(error);
+        }
         return [];
     }
 }
@@ -62,7 +81,9 @@ export async function getVersions(gid: string, aid: string, token?: vscode.Cance
         const raw: string = await httpsGet(`${URL_MAVEN_SEARCH_API}?${toQueryString(params)}`, token);
         return _.get(JSON.parse(raw), "response.docs", []);
     } catch (error) {
-        console.error(error);
+        if (!isCancellation(error)) {
+            console.error(error);
+        }
         return [];
     }
 }
@@ -85,7 +106,7 @@ export async function getLatestVersion(gid: string, aid: string): Promise<string
 async function httpsGet(urlString: string, token?: vscode.CancellationToken): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         if (token?.isCancellationRequested) {
-            reject(new Error("Cancelled"));
+            reject(new CancellationError());
             return;
         }
 
@@ -129,8 +150,15 @@ async function httpsGet(urlString: string, token?: vscode.CancellationToken): Pr
 
         if (token) {
             cancelSub = token.onCancellationRequested(() => {
-                req.destroy(new Error("Cancelled"));
+                req.destroy(new CancellationError());
             });
+            // Defensive: if the request errored synchronously before we got
+            // here, `settled` is already true and the listener above would
+            // never be disposed. Drop it now in that case.
+            if (settled) {
+                cancelSub.dispose();
+                cancelSub = undefined;
+            }
         }
     });
 }

--- a/test/unit/requestUtils.test.ts
+++ b/test/unit/requestUtils.test.ts
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Unit tests for the pom IntelliSense network hardening introduced by PR #1170
+ * (fix for issue #1127). Exercises `getArtifacts` / `getVersions` in isolation
+ * by stubbing the `https` module with a controllable fake, so we can drive
+ * `data` / `end` / `error` / `timeout` events deterministically and assert the
+ * timeout, CancellationToken, and console.error suppression behavior.
+ */
+
+import { strict as assert } from "assert";
+import { EventEmitter } from "events";
+
+// proxyquire's default export is a callable function with helper methods.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const proxyquire: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (request: string, stubs: Record<string, any>): any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    noPreserveCache: () => (request: string, stubs: Record<string, any>) => any;
+} = require("proxyquire");
+
+interface FakeRequest extends EventEmitter {
+    destroyed: boolean;
+    destroyError?: Error;
+    destroy: (err?: Error) => void;
+}
+
+interface HttpsCall {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    options: any;
+    req: FakeRequest;
+    res: EventEmitter;
+    responseCallback: (res: EventEmitter) => void;
+}
+
+interface FakeHttps {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    httpsStub: Record<string, any>;
+    calls: HttpsCall[];
+}
+
+function makeFakeHttps(): FakeHttps {
+    const calls: HttpsCall[] = [];
+    const get = (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options: any,
+        responseCallback: (res: EventEmitter) => void
+    ): FakeRequest => {
+        const req = new EventEmitter() as FakeRequest;
+        req.destroyed = false;
+        req.destroy = (err?: Error) => {
+            req.destroyed = true;
+            req.destroyError = err;
+            if (err) {
+                // Real Node emits 'error' asynchronously after destroy(err).
+                process.nextTick(() => req.emit("error", err));
+            }
+        };
+        const res = new EventEmitter();
+        calls.push({ options, req, res, responseCallback });
+        return req;
+    };
+    return {
+        calls,
+        httpsStub: { get, "@noCallThru": true }
+    };
+}
+
+interface FakeToken {
+    isCancellationRequested: boolean;
+    onCancellationRequested: (listener: () => void) => { dispose: () => void };
+    _cancel(): void;
+}
+
+function makeFakeToken(initiallyCancelled = false): FakeToken {
+    const listeners: Array<() => void> = [];
+    const tok: FakeToken = {
+        isCancellationRequested: initiallyCancelled,
+        onCancellationRequested: (listener: () => void) => {
+            listeners.push(listener);
+            return {
+                dispose: () => {
+                    const i = listeners.indexOf(listener);
+                    if (i >= 0) {
+                        listeners.splice(i, 1);
+                    }
+                }
+            };
+        },
+        _cancel: () => {
+            tok.isCancellationRequested = true;
+            for (const l of [...listeners]) {
+                l();
+            }
+        }
+    };
+    return tok;
+}
+
+interface RequestUtilsModule {
+    getArtifacts: (keywords: string[], token?: FakeToken) => Promise<Array<{ a: string }>>;
+    getVersions: (gid: string, aid: string, token?: FakeToken) => Promise<Array<{ v: string }>>;
+}
+
+function load(): { mod: RequestUtilsModule; calls: HttpsCall[] } {
+    const { httpsStub, calls } = makeFakeHttps();
+    const pq = proxyquire.noPreserveCache();
+    const mod = pq("../../src/utils/requestUtils", {
+        "https": httpsStub,
+        // requestUtils only imports `vscode` for the CancellationToken type;
+        // an empty stub is enough to satisfy the require() at runtime.
+        "vscode": { "@noCallThru": true }
+    }) as RequestUtilsModule;
+    return { mod, calls };
+}
+
+// Yield one macrotask so that the fake https.get gets invoked.
+async function flushMicrotasks(): Promise<void> {
+    await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+describe("requestUtils — PR #1170", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let consoleErrorCalls: any[][];
+    let originalConsoleError: typeof console.error;
+
+    beforeEach(() => {
+        consoleErrorCalls = [];
+        originalConsoleError = console.error;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        console.error = (...args: any[]) => { consoleErrorCalls.push(args); };
+    });
+
+    afterEach(() => {
+        console.error = originalConsoleError;
+    });
+
+    describe("getArtifacts", () => {
+        it("returns [] without making an HTTPS call when all keywords are too short (< 3 chars)", async () => {
+            const { mod, calls } = load();
+            const result = await mod.getArtifacts(["a", "ab"]);
+            assert.deepEqual(result, []);
+            assert.equal(calls.length, 0);
+            assert.equal(consoleErrorCalls.length, 0);
+        });
+
+        it("returns parsed docs on a successful response", async () => {
+            const { mod, calls } = load();
+            const promise = mod.getArtifacts(["junit"]);
+
+            await flushMicrotasks();
+            assert.equal(calls.length, 1);
+            const { res, responseCallback } = calls[0];
+            responseCallback(res);
+            res.emit("data", Buffer.from(JSON.stringify({
+                response: {
+                    docs: [{ id: "junit:junit", g: "junit", a: "junit", latestVersion: "4.13.2", versionCount: 60, p: "jar" }]
+                }
+            })));
+            res.emit("end");
+
+            const result = await promise;
+            assert.equal(result.length, 1);
+            assert.equal(result[0].a, "junit");
+            assert.equal(consoleErrorCalls.length, 0);
+        });
+
+        it("passes a 10s timeout to https.get", async () => {
+            const { mod, calls } = load();
+            const promise = mod.getArtifacts(["junit"]);
+
+            await flushMicrotasks();
+            assert.equal(calls.length, 1);
+            assert.equal(calls[0].options.timeout, 10_000);
+
+            // Tidy up so the test doesn't leave a pending promise.
+            const { res, responseCallback } = calls[0];
+            responseCallback(res);
+            res.emit("data", Buffer.from(JSON.stringify({ response: { docs: [] } })));
+            res.emit("end");
+            await promise;
+        });
+
+        it("returns [] without console.error when token is already cancelled (pre-flight short-circuit)", async () => {
+            const { mod, calls } = load();
+            const token = makeFakeToken(true);
+
+            const result = await mod.getArtifacts(["junit"], token);
+
+            assert.deepEqual(result, []);
+            assert.equal(calls.length, 0, "httpsGet must short-circuit before calling https.get");
+            assert.equal(consoleErrorCalls.length, 0, "Pre-cancelled token must not log");
+        });
+
+        it("returns [] without console.error when token is cancelled mid-flight; req is destroyed", async () => {
+            const { mod, calls } = load();
+            const token = makeFakeToken();
+            const promise = mod.getArtifacts(["junit"], token);
+
+            await flushMicrotasks();
+            assert.equal(calls.length, 1);
+
+            token._cancel();
+            const result = await promise;
+
+            assert.deepEqual(result, []);
+            assert.equal(calls[0].req.destroyed, true, "Cancellation must destroy the in-flight request");
+            assert.equal(consoleErrorCalls.length, 0, "Cancellation must not log to console.error");
+        });
+
+        it("returns [] AND logs to console.error on a real network error (non-cancellation)", async () => {
+            const { mod, calls } = load();
+            const promise = mod.getArtifacts(["junit"]);
+
+            await flushMicrotasks();
+            calls[0].req.emit("error", new Error("ECONNREFUSED"));
+
+            const result = await promise;
+            assert.deepEqual(result, []);
+            assert.equal(consoleErrorCalls.length, 1, "Real failures must still be logged");
+            assert.ok(String(consoleErrorCalls[0][0]).includes("ECONNREFUSED"));
+        });
+
+        it("on 'timeout' destroys the request with a timeout error and returns []", async () => {
+            const { mod, calls } = load();
+            const promise = mod.getArtifacts(["junit"]);
+
+            await flushMicrotasks();
+            const { req } = calls[0];
+
+            // Simulate Node's socket idle timeout — our handler calls req.destroy(err).
+            req.emit("timeout");
+
+            const result = await promise;
+            assert.deepEqual(result, []);
+            assert.equal(req.destroyed, true);
+            assert.ok(req.destroyError, "destroy should be called with an error");
+            assert.ok(/timed out/.test(req.destroyError!.message), `unexpected error: ${req.destroyError!.message}`);
+            assert.equal(consoleErrorCalls.length, 1, "Timeout is a real failure and must be logged");
+        });
+    });
+
+    describe("getVersions", () => {
+        it("returns parsed docs on a successful response", async () => {
+            const { mod, calls } = load();
+            const promise = mod.getVersions("junit", "junit");
+
+            await flushMicrotasks();
+            const { res, responseCallback } = calls[0];
+            responseCallback(res);
+            res.emit("data", Buffer.from(JSON.stringify({
+                response: { docs: [{ id: "junit:junit:4.13.2", g: "junit", a: "junit", v: "4.13.2", timestamp: 0 }] }
+            })));
+            res.emit("end");
+
+            const result = await promise;
+            assert.equal(result.length, 1);
+            assert.equal(result[0].v, "4.13.2");
+            assert.equal(consoleErrorCalls.length, 0);
+        });
+
+        it("returns [] silently when token is cancelled mid-flight", async () => {
+            const { mod, calls } = load();
+            const token = makeFakeToken();
+            const promise = mod.getVersions("junit", "junit", token);
+
+            await flushMicrotasks();
+            assert.equal(calls.length, 1);
+            token._cancel();
+
+            const result = await promise;
+            assert.deepEqual(result, []);
+            assert.equal(consoleErrorCalls.length, 0);
+        });
+    });
+});


### PR DESCRIPTION
## What

Defensive hardening of the pom.xml IntelliSense completion path so that an unreachable / slow Maven Central no longer leaves the suggestions popup stuck on `Loading...` forever.

Refs #1127.

## Why

In #1127 a user reports that `Ctrl+Space` brings up the suggestions popup but it stays on `Loading...` indefinitely. We've asked for more info to confirm the root cause (pom.xml vs Java file, network environment, logs), but regardless of the exact root cause in their setup, the existing completion code has a real "infinite Loading…" hazard worth fixing.

Tracing the pom completion provider:

- `src/extension.ts` registers `PomCompletionProvider` for `pom.xml` with trigger characters `.`, `-`, `<`.
- `PomCompletionProvider.provideCompletionItems` previously `await`ed each sub-provider serially and **ignored the `CancellationToken`** VS Code passes in.
- The `ArtifactProvider` fan-out (Maven Central / index / local) was also fully serial: a slow source blocked all the others.
- The HTTPS helper in `src/utils/requestUtils.ts` had:
  - no socket / request timeout — a stuck TCP connection (proxy, DNS black hole, unreachable Maven Central) left the Promise pending forever;
  - no request-level `error` handler, only a response-level one;
  - no awareness of `CancellationToken`.

Combined, that means **one hung HTTPS call to `search.maven.org` is enough to make the completion popup stay on `Loading...` until VS Code is restarted** — matching the symptom in #1127.

## What changed

- `src/utils/requestUtils.ts`
  - Adds a 10 s timeout (`options.timeout` + `req.on('timeout')` → `req.destroy(...)`).
  - Adds a request-level `error` handler.
  - Adds a single `settle` guard so the Promise can only resolve or reject once.
  - Optionally accepts a `vscode.CancellationToken` and aborts the request via `req.destroy()` on cancellation.
  - Introduces a dedicated `CancellationError` class so that completion-side cancellations (which fire on every keystroke as VS Code supersedes the previous token) do **not** spam `console.error`. `getArtifacts` / `getVersions` suppress logging for that class only.
  - Re-checks the `settled` flag immediately after subscribing to `token.onCancellationRequested`, closing a tiny race where a synchronous error from `https.get` could leave the cancellation listener undisposed.
- `src/completion/PomCompletionProvider.ts`
  - Honors the `CancellationToken` (early-out before parsing the doc, and after fan-out).
  - Runs the registered sub-providers concurrently with `Promise.all` + per-provider `catch` so one failing provider can no longer block the others.
- `src/completion/providers/ArtifactProvider.ts`
  - Switches the central / index / local fan-out to `Promise.allSettled`: a network failure on Maven Central still returns local and index results.
  - Forwards the token to `FromCentral` (the only sub-provider that performs real network I/O — `FromIndex` is an in-process JDT.LS RPC and `FromLocal` is a `fast-glob` over `~/.m2/repository`; neither has a public abort API).
- `src/completion/providers/IXmlCompletionProvider.ts` / `IArtifactProvider.ts` / `FromCentral.ts`
  - Optional `token` parameter plumbing. Existing implementations remain compatible.

## Behavior summary

- **Healthy network**: same result set as before, sourced from all three providers. Tiny perf win because the three sources now run concurrently instead of serially.
- **Unreachable Maven Central**: completion popup now resolves within ~10 s with whatever local / index results are available, instead of staying on `Loading...` indefinitely.
- **User cancels (types, moves cursor, presses Esc)**: in-flight HTTPS requests are aborted instead of running to completion.

### Intentional behavior change in `getArtifacts` / `getVersions`

The existing `try/catch` in these helpers only wrapped `JSON.parse`. I widened the `try` to also wrap the `await httpsGet(...)` call. Net effect:

- **Before**: a network-level rejection from `httpsGet` propagated out of `getArtifacts` / `getVersions`. The completion path tolerated this (it caught at a higher level), but the command-handler callers (`src/handlers/addDependencyHandler.ts`, `src/handlers/setDependencyVersionHandler.ts`) would surface an unhandled rejection.
- **After**: any error (timeout, DNS failure, JSON parse failure) returns `[]`. Command handlers now show an empty quick pick instead of failing, which is the safer UX when Maven Central is unreachable.

This is intentional but worth calling out for reviewers.

## Tests

Added `test/unit/requestUtils.test.ts` (9 cases) covering the changed behavior. Tests stub `https` via `proxyquire` and drive the underlying state machine through `data` / `end` / `error` / `timeout` events:

| Case | Asserts |
|---|---|
| short keywords | no HTTPS call, returns `[]` |
| 200 response | parses docs |
| `options.timeout` | equals 10 000 ms |
| pre-cancelled token | short-circuits, no `console.error` |
| cancel mid-flight | `req.destroy` called, no `console.error` |
| non-cancellation error (`ECONNREFUSED`) | returns `[]`, **does** log |
| socket `timeout` event | destroys req with timeout error, logs |
| `getVersions` success | parses docs |
| `getVersions` cancel | silent, returns `[]` |

`.mocharc.json` also gains `"node-option": ["no-experimental-strip-types"]` to work around a Node 22.18+ default that caused newly created `.test.ts` files to be loaded by Mocha through Node's ESM strip-types path instead of the pre-existing `ts-node/register/transpile-only` CommonJS hook (so `require()` was undefined in the new file). With the flag set, all `.test.ts` files load uniformly via ts-node.

## Validation

- `npm run compile` — clean.
- `npm run tslint` — no new warnings.
- `npm run test:unit` — **30 passing** (21 pre-existing + 9 new).
- `npm run webpack` — bundles successfully.

## Notes for reviewer

- `getLatestVersion` and `fetchPluginMetadataXml` also use `httpsGet` and automatically get the new 10 s timeout. I intentionally did not change their public signatures (no caller passes a token today).
- I considered making the 10 s timeout configurable via `maven.completion.timeoutMs` but kept it as a constant for now to minimize surface area; happy to expose it as a setting if reviewers want.
- This change does **not** touch the JDT.LS-side Maven plugin (`jdtls.ext/com.microsoft.java.maven.plugin`). If #1127 turns out to be Java-side IntelliSense rather than pom.xml IntelliSense, the actual root cause likely lives there or in `redhat.java` / JDT.LS, and we'll need the additional info requested on the issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
