### PR TITLE
ci: route ADO pipeline npm restore through CFS feed

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -17,6 +17,16 @@ trigger:
   branches:
     include:
       - main
+# Declared explicitly so the ADO definition picks up a pullRequest trigger and the
+# Azure Pipelines GitHub app reports a check on pull requests. Without this the
+# definition carries a continuousIntegration trigger only, which is why PRs to this
+# repository never showed an ADO check. This has no effect while the definition
+# overrides the YAML pull request trigger, so PR validation must also be enabled on
+# the definition itself (Triggers -> Pull request validation).
+pr:
+  branches:
+    include:
+      - main
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -2,8 +2,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -2,6 +2,8 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -45,10 +47,11 @@ extends:
                 displayName: 'Use Node.js 20.x'
                 inputs:
                   versionSpec: '20.x'
-              - task: Npm@1
+              - template: /.azure-pipelines/npm-cfs.yml@self
+              - task: CmdLine@2
                 displayName: 'npm install'
                 inputs:
-                  verbose: false
+                  script: npm install
               - task: Npm@1
                 displayName: 'npm run tslint'
                 inputs:

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -2,8 +2,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 schedules:
   - cron: 0 3 * * *
     branches:

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -2,6 +2,8 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 schedules:
   - cron: 0 3 * * *
     branches:
@@ -47,6 +49,7 @@ extends:
                 displayName: Use Node 20.x
                 inputs:
                   versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: PowerShell@2
                 displayName: Download JDK 21
                 inputs:
@@ -54,10 +57,10 @@ extends:
                   script: |-
                     New-Item -ItemType Directory -Path "$env:AGENT_TEMPDIRECTORY\downloadjdk"
                     Invoke-WebRequest -Uri "https://aka.ms/download-jdk/microsoft-jdk-21-windows-x64.zip" -OutFile "$env:AGENT_TEMPDIRECTORY\downloadjdk\microsoft-jdk-21-windows-x64.zip"
-              - task: Npm@1
+              - task: CmdLine@2
                 displayName: 'npm install'
                 inputs:
-                  verbose: false
+                  script: npm install
               - task: Npm@1
                 displayName: 'npm run tslint'
                 inputs:

--- a/.azure-pipelines/npm-cfs-variables.yml
+++ b/.azure-pipelines/npm-cfs-variables.yml
@@ -1,0 +1,26 @@
+# Variables required to route npm package restore through the Central Feed Service
+# (CFS). Consumed by every pipeline in this directory alongside the npm-cfs.yml steps
+# template, which is where these values are actually applied.
+#
+# Both are declared here rather than in each pipeline so the feed URL exists in
+# exactly one place.
+#
+# npm_config_registry is not redundant with the registry written into the generated
+# .npmrc. npm resolves configuration in the order cli > environment > project .npmrc >
+# user .npmrc, so a registry supplied only through the user config is outranked by
+# anything closer to the working directory, and by any task that substitutes its own
+# user config. Both happen here: the Npm@1 tasks that run `npm run tslint`,
+# `npm run compile` and `npm run build-plugin` generate their own .npmrc and point
+# npm_config_userconfig at it for the duration of the step. An environment variable
+# outranks every .npmrc file, so it is the only form of the redirect that survives.
+#
+# npm matches npm_config_* environment variables case insensitively, so the
+# uppercased form that Azure Pipelines exports applies to every step on every OS.
+# That matters because the pipelines span both Windows (VSEng-MicroBuildVSStable)
+# and Linux (1ES_JavaTooling_Ubuntu-2004) pools.
+
+variables:
+  - name: npm_config_registry
+    value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -1,20 +1,24 @@
-# Single source of truth for routing npm package restore through the Central Feed
-# Service (CFS), as required by SFI Network Isolation. Every build pipeline in this
-# directory consumes this template, so the feed URL is declared exactly once.
+# Routes npm package restore through the Central Feed Service (CFS), as required by
+# SFI Network Isolation. Consumed by every build pipeline in this directory.
+#
+# Pipelines must also include the companion variables template:
+#   variables:
+#     - template: /.azure-pipelines/npm-cfs-variables.yml@self
+# which declares the feed URL and the generated .npmrc path. The redirect itself is
+# carried by the npm_config_registry environment variable that template exports; see
+# its header for why the generated .npmrc alone is not enough in this repository.
 #
 # The .npmrc is generated at build time into the agent temp directory rather than
-# being committed to the repository, so that:
+# being committed, so that:
 #   * open source contributors and the GitHub Actions workflows keep restoring from
-#     the public npm registry -- npm rewrites the host of every `resolved` URL in
-#     package-lock.json to the configured registry, so a single lockfile serves both;
+#     the public npm registry;
 #   * the credential that NpmAuthenticate injects never lands inside the workspace;
 #   * the configuration does not depend on the repository being checked out, so
 #     release jobs consuming a prebuilt artifact work the same way as build jobs.
 #
-# Pipelines consuming this template must also declare the pipeline level variable
-#   npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
-# npm matches npm_config_* environment variables case insensitively, so the
-# uppercased form that Azure Pipelines exports applies to every step on every OS.
+# The registry is still written into that file because NpmAuthenticate discovers the
+# registries to authenticate by reading it. npm then takes the URL from the
+# environment and the matching credential from this file.
 #
 # The file is written with `npm config set` rather than a shell redirect because the
 # pipelines span both Windows (VSEng-MicroBuildVSStable) and Linux
@@ -26,14 +30,14 @@
 # This template must run after the Node install task, and before any step that
 # restores packages -- including `npx`, which resolves downloads through the
 # configured registry.
-
-parameters:
-  - name: npmrcPath
-    type: string
-    default: $(Agent.TempDirectory)/.npmrc
+#
+# Consumers must reference this file as `/.azure-pipelines/npm-cfs.yml@self`. A
+# relative path is resolved against the file doing the including, which for these
+# pipelines is the extends template in another repository, so the unqualified form is
+# looked up in MicroBuildTemplate or 1ESPipelineTemplates and fails YAML compilation.
 
 steps:
-  - script: npm config set registry https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/ --location=user --userconfig="${{ parameters.npmrcPath }}"
+  - script: npm config set registry $(npm_config_registry) --location=user --userconfig="$(npm_config_userconfig)"
     displayName: Configure CFS npm registry
 
   # Appends `//pkgs.dev.azure.com/.../registry/:_authToken=<token>` for every registry
@@ -42,4 +46,15 @@ steps:
   - task: NpmAuthenticate@0
     displayName: Authenticate to CFS feed
     inputs:
-      workingFile: ${{ parameters.npmrcPath }}
+      workingFile: $(npm_config_userconfig)
+
+  # Restore silently falling back to the public registry is the failure mode this
+  # whole template exists to prevent, and it leaves no trace in the build log, so it
+  # is asserted rather than assumed. The check runs from the directory that actually
+  # restores packages, which in this repository is the sources root. Written in node,
+  # which the preceding Node install task guarantees, to avoid shell differences
+  # between the Windows and Linux pools.
+  - script: |
+      node -e "const cp=require('child_process');const r=cp.execSync('npm config get registry').toString().trim();console.log('npm registry -> '+r);if(!r.startsWith('https://pkgs.dev.azure.com/')){console.error('##vso[task.logissue type=error]npm is not configured against the CFS feed');process.exit(1);}"
+    displayName: Verify CFS npm registry
+    workingDirectory: $(Build.SourcesDirectory)

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -1,0 +1,45 @@
+# Single source of truth for routing npm package restore through the Central Feed
+# Service (CFS), as required by SFI Network Isolation. Every build pipeline in this
+# directory consumes this template, so the feed URL is declared exactly once.
+#
+# The .npmrc is generated at build time into the agent temp directory rather than
+# being committed to the repository, so that:
+#   * open source contributors and the GitHub Actions workflows keep restoring from
+#     the public npm registry -- npm rewrites the host of every `resolved` URL in
+#     package-lock.json to the configured registry, so a single lockfile serves both;
+#   * the credential that NpmAuthenticate injects never lands inside the workspace;
+#   * the configuration does not depend on the repository being checked out, so
+#     release jobs consuming a prebuilt artifact work the same way as build jobs.
+#
+# Pipelines consuming this template must also declare the pipeline level variable
+#   npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
+# npm matches npm_config_* environment variables case insensitively, so the
+# uppercased form that Azure Pipelines exports applies to every step on every OS.
+#
+# The file is written with `npm config set` rather than a shell redirect because the
+# pipelines span both Windows (VSEng-MicroBuildVSStable) and Linux
+# (1ES_JavaTooling_Ubuntu-2004) pools. `script:` maps to CmdLine@2, which runs on
+# both, and the npm invocation itself is shell agnostic. PowerShell@2 is avoided
+# because it resolves `pwsh` before `powershell` and hard fails when neither is on
+# PATH, which is not guaranteed on a custom Linux image.
+#
+# This template must run after the Node install task, and before any step that
+# restores packages -- including `npx`, which resolves downloads through the
+# configured registry.
+
+parameters:
+  - name: npmrcPath
+    type: string
+    default: $(Agent.TempDirectory)/.npmrc
+
+steps:
+  - script: npm config set registry https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/ --location=user --userconfig="${{ parameters.npmrcPath }}"
+    displayName: Configure CFS npm registry
+
+  # Appends `//pkgs.dev.azure.com/.../registry/:_authToken=<token>` for every registry
+  # it finds in the file above. `always-auth` is deliberately not written: it is not
+  # read by this task and is rejected outright by the npm 10 shipped with Node 20.
+  - task: NpmAuthenticate@0
+    displayName: Authenticate to CFS feed
+    inputs:
+      workingFile: ${{ parameters.npmrcPath }}

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -2,8 +2,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 schedules:
   - cron: 0 3 * * *
     branches:

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -2,6 +2,8 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 schedules:
   - cron: 0 3 * * *
     branches:
@@ -47,6 +49,7 @@ extends:
                 displayName: Use Node 20.x
                 inputs:
                   versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: PowerShell@2
                 displayName: Download JDK 21
                 inputs:
@@ -54,10 +57,10 @@ extends:
                   script: |-
                     New-Item -ItemType Directory -Path "$env:AGENT_TEMPDIRECTORY\downloadjdk"
                     Invoke-WebRequest -Uri "https://aka.ms/download-jdk/microsoft-jdk-21-windows-x64.zip" -OutFile "$env:AGENT_TEMPDIRECTORY\downloadjdk\microsoft-jdk-21-windows-x64.zip"
-              - task: Npm@1
+              - task: CmdLine@2
                 displayName: 'npm install'
                 inputs:
-                  verbose: false
+                  script: npm install
               - task: Npm@1
                 displayName: 'npm run tslint'
                 inputs:

--- a/.azure-pipelines/release-nightly.yml
+++ b/.azure-pipelines/release-nightly.yml
@@ -8,8 +8,7 @@ name: $(Date:yyyyMMdd).$(Rev:r) # Use the current date and a revision number for
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/release-nightly.yml
+++ b/.azure-pipelines/release-nightly.yml
@@ -8,6 +8,8 @@ name: $(Date:yyyyMMdd).$(Rev:r) # Use the current date and a revision number for
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -46,6 +48,7 @@ extends:
                 displayName: 'Use Node.js 20.x'
                 inputs:
                   version: '20.x'
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: AzureCLI@2
                 displayName: 'Publish Extension'
                 inputs:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,8 +8,7 @@ name: $(Date:yyyyMMdd).$(Rev:r) # Use the current date and a revision number for
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,6 +8,8 @@ name: $(Date:yyyyMMdd).$(Rev:r) # Use the current date and a revision number for
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -46,6 +48,7 @@ extends:
                 displayName: 'Use Node.js 20.x'
                 inputs:
                   version: '20.x'
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: AzureCLI@2
                 displayName: 'Publish Extension'
                 inputs:


### PR DESCRIPTION
Routes npm package restore in the five Azure DevOps pipelines through the Central Feed Service (CFS) feed `mseng/VSJava/vscjava`, as required by SFI Network Isolation.

Starts from [microsoft/vscode-java-pack#1708](https://github.com/microsoft/vscode-java-pack/pull/1708) (the CFS routing) and [#1711](https://github.com/microsoft/vscode-java-pack/pull/1711) (the template path fix), applied together so this repo never lands the broken intermediate state, then follows [microsoft/vscode-gradle#1901](https://github.com/microsoft/vscode-gradle/pull/1901) -- the form that actually passed ADO CI -- for the `npm_config_registry` redirect and the verification step. See [Why npm_config_registry](#why-npm_config_registry).

## Why

The five pipelines under `.azure-pipelines/` restore packages straight from `registry.npmjs.org`. Under SFI Network Isolation, build pipelines must stop pulling from public feeds and instead restore through CFS, a governed feed that mirrors, caches and scans upstream packages. Until that happens the pipelines require open outbound internet and cannot run on a network isolated 1ES pool.

## What changed

Two new templates under `.azure-pipelines/`:

* `npm-cfs-variables.yml` declares the feed URL and the generated `.npmrc` path, so the URL exists in exactly one place.
* `npm-cfs.yml` writes the `.npmrc` into `$(Agent.TempDirectory)`, runs `NpmAuthenticate@0` against it, and then asserts the effective registry.

Each of the five pipelines includes the variables template and, immediately after its Node install task, the steps template:

```yaml
variables:
  - template: /.azure-pipelines/npm-cfs-variables.yml@self
```
```yaml
- template: /.azure-pipelines/npm-cfs.yml@self
```

`Npm@1` is replaced with `CmdLine@2` running `npm install` in `ci.yml`, `nightly.yml` and `rc.yml`, per vscode-java-pack#1708: the `NpmAuthenticate@0` documentation states it must not be combined with the npm task, and `Npm@1` defaults to `customRegistry: useNpmrc`, which resolves configuration from the working directory instead of the generated file.

`package.json` and `package-lock.json` are untouched, and every `npm` and `npx` invocation is character for character what it was before.

## Why npm_config_registry

vscode-gradle found this the hard way. The first run of its PR restored 589 + 129 packages with no error, yet the `vscjava` feed had cached **nothing** -- restore had silently fallen back to `registry.npmjs.org`. npm resolves configuration in the order

```
cli > environment > project .npmrc > user .npmrc > global > builtin > default
```

so a registry supplied only through the generated user config is outranked by anything closer to the working directory, and by any task that substitutes its own user config.

In vscode-gradle the culprit was committed `extension/.npmrc` and `npm-package/.npmrc` files. **This repository commits no `.npmrc`**, so it is not exposed to that exact path -- but the remaining `Npm@1` tasks reach the same outcome. `npm run tslint`, `npm run compile` and `npm run build-plugin` each generate their own `.npmrc` and repoint `npm_config_userconfig` at it for the duration of the step, discarding the CFS configuration.

An environment variable outranks every `.npmrc` file, so `npm_config_registry` is the only form of the redirect that survives. Verified locally against npm 10:

| config | effective registry |
| --- | --- |
| local config only | `https://packagefeedproxy.microsoft.io/npm/` |
| plus `npm_config_registry` env var | `https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/` |

The registry is still written into the generated `.npmrc` because that is how `NpmAuthenticate@0` discovers which registries to authenticate; npm then takes the URL from the environment and the matching credential from that file.

Because this failure mode is silent, the template ends with a `Verify CFS npm registry` step that reads the effective registry and fails the build if it is not the CFS feed. Both branches of that check were exercised locally.

## Why the template path is absolute

All five pipelines pass their steps into an `extends` template in another repository -- `MicroBuildTemplate` for `nightly.yml` and `rc.yml`, `1ESPipelineTemplates` for the rest. A relative template path is resolved against the file doing the including, which is the extends template, not the pipeline -- so a bare `npm-cfs.yml` is looked up in the template repository and fails YAML compilation for every pipeline. That is exactly what vscode-java-pack#1711 had to fix after #1708. Hence `/.azure-pipelines/npm-cfs.yml@self`, per the [template documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#store-templates-in-other-repositories).

## Why the .npmrc is generated instead of committed

This is a public repository. A committed `.npmrc` pointing at an internal feed would break outside contributors and the GitHub Actions workflows under `.github/workflows/`, which run with no Azure credentials. Generating it into the agent temp directory keeps the workspace clean and keeps the injected credential out of the checked out sources. One lockfile serves both audiences: every `resolved` URL in `package-lock.json` points at `registry.npmjs.org`, and npm replaces that host with the configured registry.

## Pull request trigger

A second, related change: `.azure-pipelines/ci.yml` gains an explicit `pr:` block.

PRs to this repository never get an ADO check, and the `azure-pipelines[bot]` never offers the `/azp run` affordance that `microsoft/vscode-gradle` has. The cause is not the YAML -- it is the ADO definition:

| | `microsoft.vscode-gradle.CI` (11720) | `microsoft.vscode-maven-CI` (11975) |
| --- | --- | --- |
| Repo type / `reportBuildStatus` | GitHub / `true` | GitHub / `true` |
| Triggers | `continuousIntegration` **+ `pullRequest`** | `continuousIntegration` **only** |
| PR trigger settings | `branchFilters: ["+main"]`, `isCommentRequiredForPullRequest: true`, `isCommentRequiredForInternalRepoPRs: true`, fork protection on | *(absent)* |

With no `pullRequest` trigger the Azure Pipelines app never associates the pipeline with a pull request, so there is no check to report and `/azp run` has nothing to start. That matches the observed history: none of #1165 through #1175 carried an ADO check.

`ci.yml` declared no `pr:` key at all. For a GitHub backed pipeline that would normally default PR validation to enabled, so its absence from the definition means it was explicitly turned off there.

**The YAML alone is not sufficient.** A definition level override takes precedence, so pull request validation also has to be enabled on definition 11975 (Triggers -> Pull request validation), ideally mirroring the gradle settings.

## Notes

`networkIsolationPolicy` is deliberately not set here. Specifying it in YAML replaces the full set of non required policies, so declaring `CFSClean` without also naming the current base policy would block everything. That should be enabled separately.

`rc.yml`, `release.yml` and `release-nightly.yml` are `trigger: none`, so they cannot accumulate the violation free runs the automated 7 day lock-in requires. Those need the `AzRF.Onboard` path through the SR21 bridge. `nightly.yml` is the only pipeline on a schedule.

Out of scope, and not npm package feeds, but worth confirming against the CFSClean endpoint list: `NodeTool@0`/`UseNode@1` fetch Node from nodejs.org on a tool cache miss, `APIScan@2` resolves `toolVersion: Latest`, MicroBuild signing restores from the internal `MicroBuildToolset` NuGet feed, and `npm run build-plugin` shells out to `mvnw clean package` in `jdtls.ext/`, which is a **Maven Central restore**. Neither vscode-java-pack nor vscode-gradle needed the Maven case addressed in their CFS PRs; if the policy for these pipelines also flags Maven, that needs a separate mirror configuration.
