### PR TITLE
ci: run npm through script steps instead of the Npm@1 task

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -61,30 +61,18 @@ extends:
                 displayName: 'npm install'
                 inputs:
                   script: npm install
-              - task: Npm@1
+              - script: npm run tslint
                 displayName: 'npm run tslint'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run tslint'
-              - task: Npm@1
+              - script: npm run compile
                 displayName: 'npm run compile'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run compile'
               - task: JavaToolInstaller@0
                 displayName: Use Java 21
                 inputs:
                   versionSpec: "21"
                   jdkArchitectureOption: x64
                   jdkSourceOption: PreInstalled
-              - task: Npm@1
+              - script: npm run build-plugin
                 displayName: 'npm run build-plugin'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run build-plugin'
               - script: 'npx @vscode/vsce@latest package'
                 displayName: 'package vsix'
               - task: CopyFiles@2

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -60,18 +60,10 @@ extends:
                 displayName: 'npm install'
                 inputs:
                   script: npm install
-              - task: Npm@1
+              - script: npm run tslint
                 displayName: 'npm run tslint'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run tslint'
-              - task: Npm@1
+              - script: npm run compile
                 displayName: 'npm run compile'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run compile'
               - task: JavaToolInstaller@0
                 displayName: 'Use Java 21'
                 inputs:
@@ -82,12 +74,8 @@ extends:
                   jdkDestinationDirectory: $(Agent.ToolsDirectory)/ms-jdk21
               - script: java --version
                 displayName: 'Check Java installation'
-              - task: Npm@1
+              - script: npm run build-plugin
                 displayName: 'npm run build-plugin'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run build-plugin'
               - task: CmdLine@2
                 displayName: Update nightly vsix version
                 inputs:

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -60,18 +60,10 @@ extends:
                 displayName: 'npm install'
                 inputs:
                   script: npm install
-              - task: Npm@1
+              - script: npm run tslint
                 displayName: 'npm run tslint'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run tslint'
-              - task: Npm@1
+              - script: npm run compile
                 displayName: 'npm run compile'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run compile'
               - task: JavaToolInstaller@0
                 displayName: 'Use Java 21'
                 inputs:
@@ -82,12 +74,8 @@ extends:
                   jdkDestinationDirectory: $(Agent.ToolsDirectory)/ms-jdk21
               - script: java --version
                 displayName: 'Check Java installation'
-              - task: Npm@1
+              - script: npm run build-plugin
                 displayName: 'npm run build-plugin'
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: 'run build-plugin'
               - task: CmdLine@2
                 displayName: Replace AI key
                 inputs:


### PR DESCRIPTION
## Problem

`#1175` routed npm restore through the Central Feed Service (CFS) using two job level settings:

- `npm_config_registry` — the CFS feed URL, exported as an environment variable
- `npm_config_userconfig` — `$(Agent.TempDirectory)/.npmrc`, into which `NpmAuthenticate@0` writes the feed credential

The `Npm@1` task is incompatible with that arrangement. It generates its own `.npmrc` and points npm at it by setting `npm_config_userconfig` itself, which discards the credential. The registry is unaffected, because it arrives as an environment variable and npm ranks environment above every config file. The task therefore requests packages from the CFS feed with no token.

`#1175` converted the `npm install` step to `CmdLine@2`, so this repository does not fail today. The nine remaining `Npm@1` steps — `npm run tslint`, `npm run compile` and `npm run build-plugin` across ci, nightly and rc — do not reach the registry either, so they pass as well. They are nevertheless running against the CFS feed unauthenticated, and any script that later resolves a package, an `npx` invocation for example, would fail.

The same configuration did fail in `microsoft/vscode-java-debug`, where the step left as `Npm@1` happened to be `npm install`. From [build 31831248](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31831248):

```
registry   = "https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/"
userconfig = "/mnt/vss/_work/1/npm/31831248.npmrc"

npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

## Change

The remaining `Npm@1` steps become plain `script:` steps, which inherit both the registry and the userconfig from the job environment.

```yaml
- task: Npm@1                    →   - script: npm run compile
  displayName: 'npm run compile'       displayName: 'npm run compile'
  inputs:
    command: custom
    verbose: false
    customCommand: 'run compile'
```

No `Npm@1` task remains in the repository, so one mechanism now applies to every npm invocation. Display names are preserved.

The equivalent change was made in `vscode-java-debug`, `vscode-java-dependency`, `vscode-java-test`, `vscode-spring-initializr` and `vscode-spring-boot-dashboard`.

## Validation

Each affected pipeline definition was expanded through the Azure DevOps pipeline preview API on this branch; all compile and retain the CFS steps.

`vscode-java-debug` [build 31831456](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31831456) confirms the converted form restores successfully through CFS.

## Context

SFI Network Isolation / MountainPass SR21, ICM 840100965.
