### PR TITLE
build: drop the unreachable snapshot repository and pin p2 to its origin

### DIFF
--- a/jdtls.ext/pom.xml
+++ b/jdtls.ext/pom.xml
@@ -110,13 +110,4 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>oss.sonatype.org</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/scripts/build-jdtls-ext.js
+++ b/scripts/build-jdtls-ext.js
@@ -10,4 +10,7 @@ const cp = require('child_process');
 const path = require('path');
 const serverDir = path.join(__dirname, '..', 'jdtls.ext');
 
-cp.execSync(`${mvnw()} clean package`, { cwd: serverDir, stdio: [0, 1, 2] });
+// `eclipse.p2.mirrors=false` stops p2 from following download.eclipse.org's mirror
+// redirect, which hands out a different third party host per request and makes the
+// set of addresses the build contacts impossible to express as an allow list.
+cp.execSync(`${mvnw()} clean package -Declipse.p2.mirrors=false`, { cwd: serverDir, stdio: [0, 1, 2] });


### PR DESCRIPTION
Part of the remediation for ICM [840100965](https://portal.microsofticm.com/imp/v5/incidents/details/840100965/summary) (MountainPass SR21, SFI Network Isolation / CFS adoption). The npm side of this pipeline is handled by #1176; this PR is the Maven side.

The goal of SR21 is that a build can run on a network isolated pool. That requires knowing every host the build contacts. This PR removes two obstacles to that, neither of which changes what the build produces.

## 1. `oss.sonatype.org` is unreachable by construction

`jdtls.ext/pom.xml` declares a **snapshots** repository, but every artifact resolved against it carries a **release** version, so Maven can only ever get a 404 back. Build [31831572](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31831572):

| | count |
|---|---|
| `Downloading from oss.sonatype.org` | 122 |
| `Downloaded from oss.sonatype.org` | **0** |

Every one of those 122 requests failed and Maven fell back to Central. Sample of what it was asking for — all release versions:

```
.../snapshots/ch/qos/logback/logback-classic/1.5.38/logback-classic-1.5.38.jar
.../snapshots/com/google/gson/gson/2.14.0/gson-2.14.0.jar
.../snapshots/org/ow2/asm/asm/9.10.1/asm-9.10.1.jar
```

Removing the entry drops an external host and 122 failed round trips, and cannot change resolution because it never resolved anything.

## 2. p2 mirror redirects make the host set unknowable

`download.eclipse.org` answers p2 requests with a redirect to a mirror picked **per request** from a pool of third party hosts. This repository's target platform only references the jdtls and m2e snapshot repositories, and build 31831572 happened not to be redirected — but that is a property of the response, not of the build. The sibling repositories on the same Tycho version are redirected: vscode-java-test reaches eight such hosts (`mirror.cs.odu.edu`, `ftp2.osuosl.org`, `eclipse.c3sl.ufpr.br`, …) and vscode-java-dependency reaches five.

`-Declipse.p2.mirrors=false` ([Tycho system property](https://tycho.eclipseprojects.io/doc/main/SystemProperties.html); the older `-Dtycho.disableP2Mirrors=true` is deprecated) makes p2 read from the URL in the target definition, so the set of addresses contacted is the set the repository declares. Applying it here is preventive and costs nothing.

## What this does not do

Maven Central traffic (`repo.maven.apache.org`, 882 unique URLs in that build) still goes direct. Routing it through the CFS feed needs `MavenAuthenticate@0` plus a generated `settings.xml` mirror, which is a larger change and is deliberately not bundled here. After this PR the external host set for `npm run build-plugin` is:

| host | status |
|---|---|
| `repo.maven.apache.org` | to be routed through CFS (`vscjava` already has the Maven Central upstream) |
| `download.eclipse.org` | P2 — Azure Artifacts does not support the protocol, so this needs an SR21 exception |

Two named hosts is something an exception request can actually be written against.

## Verification

`npm run build-plugin` produces the same jars. The claim to check in CI is that `oss.sonatype.org` and any `mirror*` host disappear from the build log while the plugin still builds.
