### PR TITLE
build: use Node 22 for UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Node.js modules
         run: npm install
@@ -103,7 +103,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - id: list
         run: |
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Download workspace artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Use Node.js 22 across the UI Test build, plan discovery, and AutoTest jobs.
- Continue installing the latest `@vscjava/vscode-autotest` release without pinning a version.

## Reason

With Node.js 20, npm selects an older compatible AutoTest release, which retains the obsolete macOS VS Code executable path. Node.js 22 allows the workflow to consume the current AutoTest release.

## Validation

- Parsed the updated workflow as YAML.
- Confirmed the AutoTest install command remains unversioned.