### PR TITLE
fix(ci): grant no-response issue permissions

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   noResponse:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb # v0.5.0
         with:


### PR DESCRIPTION
The scheduled No Response workflow currently receives a read-only `GITHUB_TOKEN`, so attempts to comment on and close inactive issues fail with HTTP 403. Grant the job least-privilege `issues: write` permission so the action can complete successfully.

Fixes the failure in https://github.com/microsoft/vscode-maven/actions/runs/33223873067/job/99023472930.